### PR TITLE
Enforcing binary handling of aasx files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.aasx       binary


### PR DESCRIPTION
I've had trouble opening AASX files download from github via MacOS.
First I feared to have a corrupted PackageExplorer version, but then realized, that the AASX files are corrupted.
Double-checked it via certification.

Hope it gonna work via explizit binary handling.