### PR TITLE
Fix Generic Forms for SubmodelTemplaet Provission of Simulation Model

### DIFF
--- a/published/Provision of Simulation Models/1/0/IDTA 02005-1-0_Template_ProvisionOfSimulationModels.json
+++ b/published/Provision of Simulation Models/1/0/IDTA 02005-1-0_Template_ProvisionOfSimulationModels.json
@@ -1,11776 +1,8113 @@
 {
-  "assetAdministrationShells": [
-    {
-      "idShort": "ProvisionofSimulationModelsAAS",
-      "id": "https://admin-shell.io/idta/aas/SimulationModels/1/0",
-      "assetInformation": {
-        "assetKind": "Type",
-        "globalAssetId": "https://admin-shell.io/idta/aas/SimulationModels/1/0",
-        "assetType": "Type"
-      },
-      "submodels": [
+    "assetAdministrationShells": [
         {
-          "type": "ModelReference",
-          "keys": [
-            {
-              "type": "Submodel",
-              "value": "https://admin-shell.io/idta/SubmodelTemplate/SimulationModels/1/0"
-            }
-          ]
+            "idShort": "ProvisionofSimulationModelsAAS",
+            "modelType": "AssetAdministrationShell",
+            "id": "https://admin-shell.io/idta/aas/SimulationModels/1/0",
+            "assetInformation": {
+                "assetKind": "Type",
+                "globalAssetId": "https://admin-shell.io/idta/aas/SimulationModels/1/0",
+                "assetType": "Type"
+            },
+            "submodels": [
+                {
+                    "type": "ModelReference",
+                    "keys": [
+                        {
+                            "type": "Submodel",
+                            "value": "https://admin-shell.io/idta/SubmodelTemplate/SimulationModels/1/0"
+                        }
+                    ]
+                }
+            ]
         }
-      ],
-      "modelType": "AssetAdministrationShell"
-    }
-  ],
-  "submodels": [
-    {
-      "idShort": "SimulationModels",
-      "id": "https://admin-shell.io/idta/SubmodelTemplate/SimulationModels/1/0",
-      "kind": "Template",
-      "semanticId": {
-        "type": "ModelReference",
-        "keys": [
-          {
-            "type": "Submodel",
-            "value": "https://admin-shell.io/idta/SimulationModels/SimulationModels/1/0"
-          }
-        ]
-      },
-      "qualifiers": [
+    ],
+    "submodels": [
         {
-          "kind": "ConceptQualifier",
-          "type": "FormTitle",
-          "valueType": "xs:string",
-          "value": "Simulation Submodel v008"
+            "idShort": "SimulationModels",
+            "modelType": "Submodel",
+            "id": "https://admin-shell.io/idta/SubmodelTemplate/SimulationModels/1/0",
+            "semanticId": {
+                "type": "ModelReference",
+                "keys": [
+                    {
+                        "type": "Submodel",
+                        "value": "https://admin-shell.io/idta/SimulationModels/SimulationModels/1/0"
+                    }
+                ]
+            },
+            "kind": "Template",
+            "qualifiers": [
+                {
+                    "value": "Simulation Submodel v008",
+                    "kind": "ConceptQualifier",
+                    "valueType": "xs:string",
+                    "type": "FormTitle"
+                },
+                {
+                    "value": "Das Submodel kann ein oder meherer Simulationsmodelle bereitstellen, einen Service zur Generierung eines spezifischen Modells oder einen Zugang zu einer offenen oder spezifischen Anfrage.",
+                    "kind": "ConceptQualifier",
+                    "valueType": "xs:string",
+                    "type": "FormInfo"
+                }
+            ],
+            "submodelElements": [
+                {
+                    "idShort": "SimulationModel",
+                    "category": "CONSTANT",
+                    "modelType": "SubmodelElementCollection",
+                    "semanticId": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "https://admin-shell.io/idta/SimulationModels/SimulationModel/1/0"
+                            }
+                        ]
+                    },
+                    "qualifiers": [
+                        {
+                            "value": "SimulationModel",
+                            "kind": "ConceptQualifier",
+                            "valueType": "xs:string",
+                            "type": "FormTitle"
+                        },
+                        {
+                            "value": "Merkmalssammlung zur Bereitstellung oder Anfrage von Simulationsmodellen. Die Modelle k\u00f6nnen von der Zielstellung und inhaltlich beschrieben werden.",
+                            "kind": "ConceptQualifier",
+                            "valueType": "xs:string",
+                            "type": "FormInfo"
+                        },
+                        {
+                            "value": "To be filleSimulationModel'{0:00}'",
+                            "kind": "ConceptQualifier",
+                            "valueType": "xs:string",
+                            "type": "PresetIdShort"
+                        },
+                        {
+                            "value": "ZeroToMany",
+                            "kind": "ConceptQualifier",
+                            "valueType": "xs:string",
+                            "type": "Multiplicity"
+                        }
+                    ],
+                    "value": [
+                        {
+                            "idShort": "Summary",
+                            "category": "CONSTANT",
+                            "modelType": "MultiLanguageProperty",
+                            "semanticId": {
+                                "type": "ExternalReference",
+                                "keys": [
+                                    {
+                                        "type": "GlobalReference",
+                                        "value": "https://admin-shell.io/idta/SimulationModels/Summary/1/0"
+                                    }
+                                ]
+                            },
+                            "qualifiers": [
+                                {
+                                    "value": "summary",
+                                    "kind": "ConceptQualifier",
+                                    "valueType": "xs:string",
+                                    "type": "FormTitle"
+                                },
+                                {
+                                    "value": "Summary of the contents of the simulation model in text form. ",
+                                    "kind": "ConceptQualifier",
+                                    "valueType": "xs:string",
+                                    "type": "FormInfo"
+                                },
+                                {
+                                    "value": "summary",
+                                    "kind": "ConceptQualifier",
+                                    "valueType": "xs:string",
+                                    "type": "PresetIdShort"
+                                },
+                                {
+                                    "value": "ZeroToOne",
+                                    "kind": "ConceptQualifier",
+                                    "valueType": "xs:string",
+                                    "type": "Multiplicity"
+                                }
+                            ]
+                        },
+                        {
+                            "idShort": "SimPurpose",
+                            "modelType": "SubmodelElementCollection",
+                            "semanticId": {
+                                "type": "ExternalReference",
+                                "keys": [
+                                    {
+                                        "type": "GlobalReference",
+                                        "value": "https://admin-shell.io/idta/SimulationModels/SimPurpose/1/0"
+                                    }
+                                ]
+                            },
+                            "qualifiers": [
+                                {
+                                    "value": "simPurpose",
+                                    "kind": "ConceptQualifier",
+                                    "valueType": "xs:string",
+                                    "type": "FormTitle"
+                                },
+                                {
+                                    "value": "This characteristic describes the simulation purpose or suitability for different simulation goals.",
+                                    "kind": "ConceptQualifier",
+                                    "valueType": "xs:string",
+                                    "type": "FormInfo"
+                                },
+                                {
+                                    "value": "simPurpose",
+                                    "kind": "ConceptQualifier",
+                                    "valueType": "xs:string",
+                                    "type": "PresetIdShort"
+                                },
+                                {
+                                    "value": "One",
+                                    "kind": "ConceptQualifier",
+                                    "valueType": "xs:string",
+                                    "type": "Multiplicity"
+                                }
+                            ],
+                            "value": [
+                                {
+                                    "idShort": "PosSimPurpose",
+                                    "modelType": "Property",
+                                    "semanticId": {
+                                        "type": "ExternalReference",
+                                        "keys": [
+                                            {
+                                                "type": "GlobalReference",
+                                                "value": "https://admin-shell.io/idta/SimulationModels/PosSimPurpose/1/0"
+                                            }
+                                        ]
+                                    },
+                                    "qualifiers": [
+                                        {
+                                            "value": "posSimPurpose",
+                                            "kind": "ConceptQualifier",
+                                            "valueType": "xs:string",
+                                            "type": "FormTitle"
+                                        },
+                                        {
+                                            "value": "List of simulation purposes for which the model is intended.",
+                                            "kind": "ConceptQualifier",
+                                            "valueType": "xs:string",
+                                            "type": "FormInfo"
+                                        },
+                                        {
+                                            "value": "posSimPurpose'{0:00}'",
+                                            "kind": "ConceptQualifier",
+                                            "valueType": "xs:string",
+                                            "type": "PresetIdShort"
+                                        },
+                                        {
+                                            "value": "OneToMany",
+                                            "kind": "ConceptQualifier",
+                                            "valueType": "xs:string",
+                                            "type": "Multiplicity"
+                                        },
+                                        {
+                                            "value": "Concept evaluation; Sizing; Energy consumption; Control design; Behaviour in fault condition; Validation and testing; Virtual commissioning; Condition monitoring; Predictive maintenance; Operator Training; Teaching",
+                                            "kind": "ConceptQualifier",
+                                            "valueType": "xs:string",
+                                            "type": "FormChoices"
+                                        }
+                                    ],
+                                    "valueType": "xs:string"
+                                },
+                                {
+                                    "idShort": "NegSimPurpose",
+                                    "modelType": "Property",
+                                    "semanticId": {
+                                        "type": "ExternalReference",
+                                        "keys": [
+                                            {
+                                                "type": "GlobalReference",
+                                                "value": "https://admin-shell.io/idta/SimulationModels/NegSimPurpose/1/0"
+                                            }
+                                        ]
+                                    },
+                                    "qualifiers": [
+                                        {
+                                            "value": "negSimPurpose",
+                                            "kind": "ConceptQualifier",
+                                            "valueType": "xs:string",
+                                            "type": "FormTitle"
+                                        },
+                                        {
+                                            "value": "List of simulation purposes for which the model is explicitly not suitable. ",
+                                            "kind": "ConceptQualifier",
+                                            "valueType": "xs:string",
+                                            "type": "FormInfo"
+                                        },
+                                        {
+                                            "value": "negSimPurpose'{0:00}'",
+                                            "kind": "ConceptQualifier",
+                                            "valueType": "xs:string",
+                                            "type": "PresetIdShort"
+                                        },
+                                        {
+                                            "value": "ZeroToMany",
+                                            "kind": "ConceptQualifier",
+                                            "valueType": "xs:string",
+                                            "type": "Multiplicity"
+                                        },
+                                        {
+                                            "value": "Concept evaluation; Sizing; Energy consumption; Control design; Behaviour in fault condition; Validation and testing; Virtual commissioning; Condition monitoring; Predictive maintenance; Operator Training; Teaching",
+                                            "kind": "ConceptQualifier",
+                                            "valueType": "xs:string",
+                                            "type": "FormChoices"
+                                        }
+                                    ],
+                                    "valueType": "xs:string"
+                                }
+                            ]
+                        },
+                        {
+                            "idShort": "TypeOfModel",
+                            "modelType": "Property",
+                            "semanticId": {
+                                "type": "ExternalReference",
+                                "keys": [
+                                    {
+                                        "type": "GlobalReference",
+                                        "value": "https://admin-shell.io/idta/SimulationModels/TypeOfModel/1/0"
+                                    }
+                                ]
+                            },
+                            "qualifiers": [
+                                {
+                                    "value": "typeOfModel",
+                                    "kind": "ConceptQualifier",
+                                    "valueType": "xs:string",
+                                    "type": "FormTitle"
+                                },
+                                {
+                                    "value": "List of modeling approaches used for the model.",
+                                    "kind": "ConceptQualifier",
+                                    "valueType": "xs:string",
+                                    "type": "FormInfo"
+                                },
+                                {
+                                    "value": "typeOfModelDesc",
+                                    "kind": "ConceptQualifier",
+                                    "valueType": "xs:string",
+                                    "type": "PresetIdShort"
+                                },
+                                {
+                                    "value": "ZeroToMany",
+                                    "kind": "ConceptQualifier",
+                                    "valueType": "xs:string",
+                                    "type": "Multiplicity"
+                                },
+                                {
+                                    "value": "Linear model; Nonlinear model; Data-driven model; Lumped element model; Fixed causality model; Acausal model ",
+                                    "kind": "ConceptQualifier",
+                                    "valueType": "xs:string",
+                                    "type": "FormChoices"
+                                }
+                            ],
+                            "valueType": "xs:string"
+                        },
+                        {
+                            "idShort": "ScopeOfModel",
+                            "modelType": "Property",
+                            "semanticId": {
+                                "type": "ExternalReference",
+                                "keys": [
+                                    {
+                                        "type": "GlobalReference",
+                                        "value": "https://admin-shell.io/idta/SimulationModels/ScopeOfModel/1/0"
+                                    }
+                                ]
+                            },
+                            "qualifiers": [
+                                {
+                                    "value": "scopeOfModel",
+                                    "kind": "ConceptQualifier",
+                                    "valueType": "xs:string",
+                                    "type": "FormTitle"
+                                },
+                                {
+                                    "value": "List of basic physical characteristics which are represented by the model.",
+                                    "kind": "ConceptQualifier",
+                                    "valueType": "xs:string",
+                                    "type": "FormInfo"
+                                },
+                                {
+                                    "value": "scopeOfModel",
+                                    "kind": "ConceptQualifier",
+                                    "valueType": "xs:string",
+                                    "type": "PresetIdShort"
+                                },
+                                {
+                                    "value": "OneToMany",
+                                    "kind": "ConceptQualifier",
+                                    "valueType": "xs:string",
+                                    "type": "Multiplicity"
+                                },
+                                {
+                                    "value": "Logic and timing behaviour; Geometry; Kinematics; Dynamics; Distribution networks; Network communication; Visualization",
+                                    "kind": "ConceptQualifier",
+                                    "valueType": "xs:string",
+                                    "type": "FormChoices"
+                                }
+                            ],
+                            "valueType": "xs:string"
+                        },
+                        {
+                            "idShort": "LicenseModel",
+                            "modelType": "Property",
+                            "semanticId": {
+                                "type": "ExternalReference",
+                                "keys": [
+                                    {
+                                        "type": "GlobalReference",
+                                        "value": "https://admin-shell.io/idta/SimulationModels/LicenseModel/1/0"
+                                    }
+                                ]
+                            },
+                            "qualifiers": [
+                                {
+                                    "value": "licenseModel",
+                                    "kind": "ConceptQualifier",
+                                    "valueType": "xs:string",
+                                    "type": "FormTitle"
+                                },
+                                {
+                                    "value": "If a simulation model usage will be charged and how it will be charged.",
+                                    "kind": "ConceptQualifier",
+                                    "valueType": "xs:string",
+                                    "type": "FormInfo"
+                                },
+                                {
+                                    "value": "licenseModel",
+                                    "kind": "ConceptQualifier",
+                                    "valueType": "xs:string",
+                                    "type": "PresetIdShort"
+                                },
+                                {
+                                    "value": "ZeroToOne",
+                                    "kind": "ConceptQualifier",
+                                    "valueType": "xs:string",
+                                    "type": "Multiplicity"
+                                },
+                                {
+                                    "value": "free; perpetual; subscription; volume-based",
+                                    "kind": "ConceptQualifier",
+                                    "valueType": "xs:string",
+                                    "type": "FormChoices"
+                                }
+                            ],
+                            "valueType": "xs:string"
+                        },
+                        {
+                            "idShort": "EngineeringDomain",
+                            "modelType": "Property",
+                            "semanticId": {
+                                "type": "ExternalReference",
+                                "keys": [
+                                    {
+                                        "type": "GlobalReference",
+                                        "value": "https://admin-shell.io/idta/SimulationModels/EngineeringDomain/1/0"
+                                    }
+                                ]
+                            },
+                            "qualifiers": [
+                                {
+                                    "value": "engineeringDomainList",
+                                    "kind": "ConceptQualifier",
+                                    "valueType": "xs:string",
+                                    "type": "FormTitle"
+                                },
+                                {
+                                    "value": "List of engineering disciplines supported or mapped with the model. ",
+                                    "kind": "ConceptQualifier",
+                                    "valueType": "xs:string",
+                                    "type": "FormInfo"
+                                },
+                                {
+                                    "value": "engineeringDomainList'{0:00}'",
+                                    "kind": "ConceptQualifier",
+                                    "valueType": "xs:string",
+                                    "type": "PresetIdShort"
+                                },
+                                {
+                                    "value": "ZeroToMany",
+                                    "kind": "ConceptQualifier",
+                                    "valueType": "xs:string",
+                                    "type": "Multiplicity"
+                                },
+                                {
+                                    "value": "Hydraulic Engineering; Electrical Engineering; Pneumatic Engineering; Mechanical Engineering; Material Flow; Robotics; Image Processing; Data Engineering; Process Engineering; Workflow Engineering; HMI Engineering; Control Engineering",
+                                    "kind": "ConceptQualifier",
+                                    "valueType": "xs:string",
+                                    "type": "FormChoices"
+                                }
+                            ],
+                            "valueType": "xs:string"
+                        },
+                        {
+                            "idShort": "Environment",
+                            "modelType": "SubmodelElementCollection",
+                            "semanticId": {
+                                "type": "ExternalReference",
+                                "keys": [
+                                    {
+                                        "type": "GlobalReference",
+                                        "value": "https://admin-shell.io/idta/SimulationModels/Environment/1/0"
+                                    }
+                                ]
+                            },
+                            "qualifiers": [
+                                {
+                                    "value": "environment",
+                                    "kind": "ConceptQualifier",
+                                    "valueType": "xs:string",
+                                    "type": "FormTitle"
+                                },
+                                {
+                                    "value": "Information about prerequisite environments or dependencies of underlying components on the target system.",
+                                    "kind": "ConceptQualifier",
+                                    "valueType": "xs:string",
+                                    "type": "FormInfo"
+                                },
+                                {
+                                    "value": "environment",
+                                    "kind": "ConceptQualifier",
+                                    "valueType": "xs:string",
+                                    "type": "PresetIdShort"
+                                },
+                                {
+                                    "value": "ZeroToMany",
+                                    "kind": "ConceptQualifier",
+                                    "valueType": "xs:string",
+                                    "type": "Multiplicity"
+                                }
+                            ],
+                            "value": [
+                                {
+                                    "idShort": "OperatingSystem",
+                                    "modelType": "Property",
+                                    "semanticId": {
+                                        "type": "ExternalReference",
+                                        "keys": [
+                                            {
+                                                "type": "GlobalReference",
+                                                "value": "https://admin-shell.io/idta/SimulationModels/OperatingSystem/1/0"
+                                            }
+                                        ]
+                                    },
+                                    "qualifiers": [
+                                        {
+                                            "value": "operatingSystem",
+                                            "kind": "ConceptQualifier",
+                                            "valueType": "xs:string",
+                                            "type": "FormTitle"
+                                        },
+                                        {
+                                            "value": "Name of the operating system including version and architecture (e.g. Windows 10 64bit)",
+                                            "kind": "ConceptQualifier",
+                                            "valueType": "xs:string",
+                                            "type": "FormInfo"
+                                        },
+                                        {
+                                            "value": "operatingSystem'{0:00}'",
+                                            "kind": "ConceptQualifier",
+                                            "valueType": "xs:string",
+                                            "type": "PresetIdShort"
+                                        },
+                                        {
+                                            "value": "One",
+                                            "kind": "ConceptQualifier",
+                                            "valueType": "xs:string",
+                                            "type": "Multiplicity"
+                                        }
+                                    ],
+                                    "valueType": "xs:string"
+                                },
+                                {
+                                    "idShort": "ToolEnvironment",
+                                    "modelType": "Property",
+                                    "semanticId": {
+                                        "type": "ExternalReference",
+                                        "keys": [
+                                            {
+                                                "type": "GlobalReference",
+                                                "value": "https://admin-shell.io/idta/SimulationModels/ToolEnvironment/1/0"
+                                            }
+                                        ]
+                                    },
+                                    "qualifiers": [
+                                        {
+                                            "value": "toolEnvironment",
+                                            "kind": "ConceptQualifier",
+                                            "valueType": "xs:string",
+                                            "type": "FormTitle"
+                                        },
+                                        {
+                                            "value": "List with required simulation tools, interpreters, model libraries or runtime libraries. In each case the exact designation of the software producer is given as free text.",
+                                            "kind": "ConceptQualifier",
+                                            "valueType": "xs:string",
+                                            "type": "FormInfo"
+                                        },
+                                        {
+                                            "value": "toolEnvironment'{0:00}'",
+                                            "kind": "ConceptQualifier",
+                                            "valueType": "xs:string",
+                                            "type": "PresetIdShort"
+                                        },
+                                        {
+                                            "value": "ZeroToMany",
+                                            "kind": "ConceptQualifier",
+                                            "valueType": "xs:string",
+                                            "type": "Multiplicity"
+                                        }
+                                    ],
+                                    "valueType": "xs:string"
+                                },
+                                {
+                                    "idShort": "DependencyEnvironment",
+                                    "category": "CONSTANT",
+                                    "modelType": "MultiLanguageProperty",
+                                    "semanticId": {
+                                        "type": "ExternalReference",
+                                        "keys": [
+                                            {
+                                                "type": "GlobalReference",
+                                                "value": "https://admin-shell.io/idta/SimulationModels/DependencyEnvironment/1/0"
+                                            }
+                                        ]
+                                    },
+                                    "qualifiers": [
+                                        {
+                                            "value": "dependencyEnvironment",
+                                            "kind": "ConceptQualifier",
+                                            "valueType": "xs:string",
+                                            "type": "FormTitle"
+                                        },
+                                        {
+                                            "value": "Description of dependencies to associated hardware and software. ",
+                                            "kind": "ConceptQualifier",
+                                            "valueType": "xs:string",
+                                            "type": "FormInfo"
+                                        },
+                                        {
+                                            "value": "dependencyEnvironment",
+                                            "kind": "ConceptQualifier",
+                                            "valueType": "xs:string",
+                                            "type": "PresetIdShort"
+                                        },
+                                        {
+                                            "value": "ZeroToOne",
+                                            "kind": "ConceptQualifier",
+                                            "valueType": "xs:string",
+                                            "type": "Multiplicity"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "idShort": "VisualizationInformation",
+                                    "modelType": "Property",
+                                    "semanticId": {
+                                        "type": "ExternalReference",
+                                        "keys": [
+                                            {
+                                                "type": "GlobalReference",
+                                                "value": "https://admin-shell.io/idta/SimulationModels/VisualizationInformation/1/0"
+                                            }
+                                        ]
+                                    },
+                                    "qualifiers": [
+                                        {
+                                            "value": "visualizationInformation",
+                                            "kind": "ConceptQualifier",
+                                            "valueType": "xs:string",
+                                            "type": "FormTitle"
+                                        },
+                                        {
+                                            "value": "Ability to use a visualization. This can be integrated in a model or the model offers capabilities for connection. The connection can be described in more detail under ports.",
+                                            "kind": "ConceptQualifier",
+                                            "valueType": "xs:string",
+                                            "type": "FormInfo"
+                                        },
+                                        {
+                                            "value": "visualizationInformation",
+                                            "kind": "ConceptQualifier",
+                                            "valueType": "xs:string",
+                                            "type": "PresetIdShort"
+                                        },
+                                        {
+                                            "value": "ZeroToOne",
+                                            "kind": "ConceptQualifier",
+                                            "valueType": "xs:string",
+                                            "type": "Multiplicity"
+                                        },
+                                        {
+                                            "value": "separately; integrated; none",
+                                            "kind": "ConceptQualifier",
+                                            "valueType": "xs:string",
+                                            "type": "FormChoices"
+                                        }
+                                    ],
+                                    "valueType": "xs:string"
+                                },
+                                {
+                                    "idShort": "SimulationTool",
+                                    "category": "CONSTANT",
+                                    "modelType": "SubmodelElementCollection",
+                                    "semanticId": {
+                                        "type": "ExternalReference",
+                                        "keys": [
+                                            {
+                                                "type": "GlobalReference",
+                                                "value": "https://admin-shell.io/idta/SimulationModels/SimulationTool/1/0"
+                                            }
+                                        ]
+                                    },
+                                    "qualifiers": [
+                                        {
+                                            "value": "simulationTool",
+                                            "kind": "ConceptQualifier",
+                                            "valueType": "xs:string",
+                                            "type": "FormTitle"
+                                        },
+                                        {
+                                            "value": "Eigenschaften des Modells bez\u00fcglich konkreter Simulationswerkzeuge.",
+                                            "kind": "ConceptQualifier",
+                                            "valueType": "xs:string",
+                                            "type": "FormInfo"
+                                        },
+                                        {
+                                            "value": "simulationTool'{0:00}'",
+                                            "kind": "ConceptQualifier",
+                                            "valueType": "xs:string",
+                                            "type": "PresetIdShort"
+                                        },
+                                        {
+                                            "value": "OneToMany",
+                                            "kind": "ConceptQualifier",
+                                            "valueType": "xs:string",
+                                            "type": "Multiplicity"
+                                        }
+                                    ],
+                                    "value": [
+                                        {
+                                            "idShort": "SimToolName",
+                                            "category": "CONSTANT",
+                                            "modelType": "Property",
+                                            "semanticId": {
+                                                "type": "ExternalReference",
+                                                "keys": [
+                                                    {
+                                                        "type": "GlobalReference",
+                                                        "value": "https://admin-shell.io/idta/SimulationModel/SimToolName/1/0"
+                                                    }
+                                                ]
+                                            },
+                                            "qualifiers": [
+                                                {
+                                                    "value": "simToolName",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "FormTitle"
+                                                },
+                                                {
+                                                    "value": "Name of the simulation tool including version.",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "FormInfo"
+                                                },
+                                                {
+                                                    "value": "simToolName",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "PresetIdShort"
+                                                },
+                                                {
+                                                    "value": "One",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "Multiplicity"
+                                                }
+                                            ],
+                                            "valueType": "xs:string"
+                                        },
+                                        {
+                                            "idShort": "DependencySimTool",
+                                            "category": "CONSTANT",
+                                            "modelType": "Property",
+                                            "semanticId": {
+                                                "type": "ExternalReference",
+                                                "keys": [
+                                                    {
+                                                        "type": "GlobalReference",
+                                                        "value": "https://admin-shell.io/idta/SimulationModels/DependencySimTool/1/0"
+                                                    }
+                                                ]
+                                            },
+                                            "qualifiers": [
+                                                {
+                                                    "value": "dependencySimTool",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "FormTitle"
+                                                },
+                                                {
+                                                    "value": "Dependencies of Simulation Tools",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "FormInfo"
+                                                },
+                                                {
+                                                    "value": "dependencySimTool'{0:00}'",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "PresetIdShort"
+                                                },
+                                                {
+                                                    "value": "ZeroToMany",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "Multiplicity"
+                                                }
+                                            ],
+                                            "valueType": "xs:string"
+                                        },
+                                        {
+                                            "idShort": "Compiler",
+                                            "category": "CONSTANT",
+                                            "modelType": "Property",
+                                            "semanticId": {
+                                                "type": "ExternalReference",
+                                                "keys": [
+                                                    {
+                                                        "type": "GlobalReference",
+                                                        "value": "https://admin-shell.io/idta/SimulationModels/Compiler/1/0"
+                                                    }
+                                                ]
+                                            },
+                                            "qualifiers": [
+                                                {
+                                                    "value": "compiler",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "FormTitle"
+                                                },
+                                                {
+                                                    "value": "Name of necessary compiler including version",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "FormInfo"
+                                                },
+                                                {
+                                                    "value": "compiler'{0:00}'",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "PresetIdShort"
+                                                },
+                                                {
+                                                    "value": "ZeroToMany",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "Multiplicity"
+                                                }
+                                            ],
+                                            "valueType": "xs:string"
+                                        },
+                                        {
+                                            "idShort": "SolverAndTolerances",
+                                            "modelType": "SubmodelElementCollection",
+                                            "semanticId": {
+                                                "type": "ExternalReference",
+                                                "keys": [
+                                                    {
+                                                        "type": "GlobalReference",
+                                                        "value": "https://admin-shell.io/idta/SimulationModels/SolverAndTolerances/1/0"
+                                                    }
+                                                ]
+                                            },
+                                            "qualifiers": [
+                                                {
+                                                    "value": "solverAndTolerances",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "FormTitle"
+                                                },
+                                                {
+                                                    "value": "Useful settings of the simulation environment. Includes e.g. solver settings. ",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "FormInfo"
+                                                },
+                                                {
+                                                    "value": "solverAndTolerances",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "PresetIdShort"
+                                                },
+                                                {
+                                                    "value": "One",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "Multiplicity"
+                                                }
+                                            ],
+                                            "value": [
+                                                {
+                                                    "idShort": "StepSizeControlNeeded",
+                                                    "modelType": "Property",
+                                                    "semanticId": {
+                                                        "type": "ExternalReference",
+                                                        "keys": [
+                                                            {
+                                                                "type": "GlobalReference",
+                                                                "value": "https://admin-shell.io/idta/SimulationModels/StepSizeControlNeeded/1/0"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "qualifiers": [
+                                                        {
+                                                            "value": "stepSizeControlNeeded",
+                                                            "kind": "ConceptQualifier",
+                                                            "valueType": "xs:string",
+                                                            "type": "FormTitle"
+                                                        },
+                                                        {
+                                                            "value": "Solver with step size control recommended.",
+                                                            "kind": "ConceptQualifier",
+                                                            "valueType": "xs:string",
+                                                            "type": "FormInfo"
+                                                        },
+                                                        {
+                                                            "value": "stepSizeControlNeeded",
+                                                            "kind": "ConceptQualifier",
+                                                            "valueType": "xs:string",
+                                                            "type": "PresetIdShort"
+                                                        },
+                                                        {
+                                                            "value": "One",
+                                                            "kind": "ConceptQualifier",
+                                                            "valueType": "xs:string",
+                                                            "type": "Multiplicity"
+                                                        },
+                                                        {
+                                                            "value": "True; False",
+                                                            "kind": "ConceptQualifier",
+                                                            "valueType": "xs:string",
+                                                            "type": "FormChoices"
+                                                        }
+                                                    ],
+                                                    "valueType": "xs:boolean"
+                                                },
+                                                {
+                                                    "idShort": "FixedStepSize",
+                                                    "modelType": "Property",
+                                                    "semanticId": {
+                                                        "type": "ExternalReference",
+                                                        "keys": [
+                                                            {
+                                                                "type": "GlobalReference",
+                                                                "value": "https://admin-shell.io/idta/SimulationModels/FixedStepSize/1/0"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "qualifiers": [
+                                                        {
+                                                            "value": "fixedStepSize",
+                                                            "kind": "ConceptQualifier",
+                                                            "valueType": "xs:string",
+                                                            "type": "FormTitle"
+                                                        },
+                                                        {
+                                                            "value": "Fixed integration step size, if there is no adaptive step size ",
+                                                            "kind": "ConceptQualifier",
+                                                            "valueType": "xs:string",
+                                                            "type": "FormInfo"
+                                                        },
+                                                        {
+                                                            "value": "fixedStepSize",
+                                                            "kind": "ConceptQualifier",
+                                                            "valueType": "xs:string",
+                                                            "type": "PresetIdShort"
+                                                        },
+                                                        {
+                                                            "value": "ZeroToOne",
+                                                            "kind": "ConceptQualifier",
+                                                            "valueType": "xs:string",
+                                                            "type": "Multiplicity"
+                                                        }
+                                                    ],
+                                                    "valueType": "xs:float"
+                                                },
+                                                {
+                                                    "idShort": "StiffSolverNeeded",
+                                                    "modelType": "Property",
+                                                    "semanticId": {
+                                                        "type": "ExternalReference",
+                                                        "keys": [
+                                                            {
+                                                                "type": "GlobalReference",
+                                                                "value": "https://admin-shell.io/idta/SimulationModels/StiffSolverNeeded/1/0"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "qualifiers": [
+                                                        {
+                                                            "value": "stiffSolverNeeded",
+                                                            "kind": "ConceptQualifier",
+                                                            "valueType": "xs:string",
+                                                            "type": "FormTitle"
+                                                        },
+                                                        {
+                                                            "value": "Stiff solver needed.",
+                                                            "kind": "ConceptQualifier",
+                                                            "valueType": "xs:string",
+                                                            "type": "FormInfo"
+                                                        },
+                                                        {
+                                                            "value": "stiffSolverNeeded",
+                                                            "kind": "ConceptQualifier",
+                                                            "valueType": "xs:string",
+                                                            "type": "PresetIdShort"
+                                                        },
+                                                        {
+                                                            "value": "One",
+                                                            "kind": "ConceptQualifier",
+                                                            "valueType": "xs:string",
+                                                            "type": "Multiplicity"
+                                                        },
+                                                        {
+                                                            "value": "True; False",
+                                                            "kind": "ConceptQualifier",
+                                                            "valueType": "xs:string",
+                                                            "type": "FormChoices"
+                                                        }
+                                                    ],
+                                                    "valueType": "xs:boolean"
+                                                },
+                                                {
+                                                    "idShort": "SolverIncluded",
+                                                    "modelType": "Property",
+                                                    "semanticId": {
+                                                        "type": "ExternalReference",
+                                                        "keys": [
+                                                            {
+                                                                "type": "GlobalReference",
+                                                                "value": "https://admin-shell.io/idta/SimulationModels/SolverIncluded/1/0"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "qualifiers": [
+                                                        {
+                                                            "value": "solverIncluded",
+                                                            "kind": "ConceptQualifier",
+                                                            "valueType": "xs:string",
+                                                            "type": "FormTitle"
+                                                        },
+                                                        {
+                                                            "value": "Solver is integrated in the model (e.g. FMU for co-simulation)",
+                                                            "kind": "ConceptQualifier",
+                                                            "valueType": "xs:string",
+                                                            "type": "FormInfo"
+                                                        },
+                                                        {
+                                                            "value": "solverIncluded",
+                                                            "kind": "ConceptQualifier",
+                                                            "valueType": "xs:string",
+                                                            "type": "PresetIdShort"
+                                                        },
+                                                        {
+                                                            "value": "One",
+                                                            "kind": "ConceptQualifier",
+                                                            "valueType": "xs:string",
+                                                            "type": "Multiplicity"
+                                                        },
+                                                        {
+                                                            "value": "True; False",
+                                                            "kind": "ConceptQualifier",
+                                                            "valueType": "xs:string",
+                                                            "type": "FormChoices"
+                                                        }
+                                                    ],
+                                                    "valueType": "xs:boolean"
+                                                },
+                                                {
+                                                    "idShort": "TestedToolSolverAlgorithm",
+                                                    "modelType": "SubmodelElementCollection",
+                                                    "semanticId": {
+                                                        "type": "ExternalReference",
+                                                        "keys": [
+                                                            {
+                                                                "type": "GlobalReference",
+                                                                "value": "https://admin-shell.io/idta/SimulationModels/TestedToolSolverAlgorithm/1/0"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "qualifiers": [
+                                                        {
+                                                            "value": "testedToolSolverAlgorithm",
+                                                            "kind": "ConceptQualifier",
+                                                            "valueType": "xs:string",
+                                                            "type": "FormTitle"
+                                                        },
+                                                        {
+                                                            "value": "List of validated tool-solver combinations",
+                                                            "kind": "ConceptQualifier",
+                                                            "valueType": "xs:string",
+                                                            "type": "FormInfo"
+                                                        },
+                                                        {
+                                                            "value": "testedToolSolverAlgorithm'{0:00}'",
+                                                            "kind": "ConceptQualifier",
+                                                            "valueType": "xs:string",
+                                                            "type": "PresetIdShort"
+                                                        },
+                                                        {
+                                                            "value": "ZeroToMany",
+                                                            "kind": "ConceptQualifier",
+                                                            "valueType": "xs:string",
+                                                            "type": "Multiplicity"
+                                                        }
+                                                    ],
+                                                    "value": [
+                                                        {
+                                                            "idShort": "SolverAlgorithm",
+                                                            "modelType": "Property",
+                                                            "semanticId": {
+                                                                "type": "ExternalReference",
+                                                                "keys": [
+                                                                    {
+                                                                        "type": "GlobalReference",
+                                                                        "value": "https://admin-shell.io/idta/SimulationModels/SolverAlgorithm/1/0"
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "qualifiers": [
+                                                                {
+                                                                    "value": "solverAlgorithm",
+                                                                    "kind": "ConceptQualifier",
+                                                                    "valueType": "xs:string",
+                                                                    "type": "FormTitle"
+                                                                },
+                                                                {
+                                                                    "value": "validated solver",
+                                                                    "kind": "ConceptQualifier",
+                                                                    "valueType": "xs:string",
+                                                                    "type": "FormInfo"
+                                                                },
+                                                                {
+                                                                    "value": "solverAlgorithm",
+                                                                    "kind": "ConceptQualifier",
+                                                                    "valueType": "xs:string",
+                                                                    "type": "PresetIdShort"
+                                                                },
+                                                                {
+                                                                    "value": "One",
+                                                                    "kind": "ConceptQualifier",
+                                                                    "valueType": "xs:string",
+                                                                    "type": "Multiplicity"
+                                                                }
+                                                            ],
+                                                            "valueType": "xs:string"
+                                                        },
+                                                        {
+                                                            "idShort": "ToolSolverFurtherDescription",
+                                                            "modelType": "Property",
+                                                            "semanticId": {
+                                                                "type": "ExternalReference",
+                                                                "keys": [
+                                                                    {
+                                                                        "type": "GlobalReference",
+                                                                        "value": "https://admin-shell.io/idta/SimulationModels/ToolSolverFurtherDescription/1/0"
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "qualifiers": [
+                                                                {
+                                                                    "value": "toolSolverFurtherDescription",
+                                                                    "kind": "ConceptQualifier",
+                                                                    "valueType": "xs:string",
+                                                                    "type": "FormTitle"
+                                                                },
+                                                                {
+                                                                    "value": "Further tool- and solver-specific information",
+                                                                    "kind": "ConceptQualifier",
+                                                                    "valueType": "xs:string",
+                                                                    "type": "FormInfo"
+                                                                },
+                                                                {
+                                                                    "value": "toolSolverFurtherDescription",
+                                                                    "kind": "ConceptQualifier",
+                                                                    "valueType": "xs:string",
+                                                                    "type": "PresetIdShort"
+                                                                },
+                                                                {
+                                                                    "value": "ZeroToOne",
+                                                                    "kind": "ConceptQualifier",
+                                                                    "valueType": "xs:string",
+                                                                    "type": "Multiplicity"
+                                                                }
+                                                            ],
+                                                            "valueType": "xs:string"
+                                                        },
+                                                        {
+                                                            "idShort": "Tolerance",
+                                                            "modelType": "Property",
+                                                            "semanticId": {
+                                                                "type": "ExternalReference",
+                                                                "keys": [
+                                                                    {
+                                                                        "type": "GlobalReference",
+                                                                        "value": "https://admin-shell.io/idta/SimulationModels/Tolerance/1/0"
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "qualifiers": [
+                                                                {
+                                                                    "value": "tolerance",
+                                                                    "kind": "ConceptQualifier",
+                                                                    "valueType": "xs:string",
+                                                                    "type": "FormTitle"
+                                                                },
+                                                                {
+                                                                    "value": "(relative) tolerance for theadaptive step size ",
+                                                                    "kind": "ConceptQualifier",
+                                                                    "valueType": "xs:string",
+                                                                    "type": "FormInfo"
+                                                                },
+                                                                {
+                                                                    "value": "tolerance",
+                                                                    "kind": "ConceptQualifier",
+                                                                    "valueType": "xs:string",
+                                                                    "type": "PresetIdShort"
+                                                                },
+                                                                {
+                                                                    "value": "ZeroToOne",
+                                                                    "kind": "ConceptQualifier",
+                                                                    "valueType": "xs:string",
+                                                                    "type": "Multiplicity"
+                                                                }
+                                                            ],
+                                                            "valueType": "xs:float"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "idShort": "RefSimDocumentation",
+                            "modelType": "File",
+                            "semanticId": {
+                                "type": "ExternalReference",
+                                "keys": [
+                                    {
+                                        "type": "GlobalReference",
+                                        "value": "https://admin-shell.io/idta/SimulationModels/RefSimDocumentation/1/0"
+                                    }
+                                ]
+                            },
+                            "qualifiers": [
+                                {
+                                    "value": "refSimDocumentation",
+                                    "kind": "ConceptQualifier",
+                                    "valueType": "xs:string",
+                                    "type": "FormTitle"
+                                },
+                                {
+                                    "value": "Documentation of example simulations of the model can be supplied. This includes a solver setup and sample circuit and sample results. e.g. zip file, PDF, html, ...",
+                                    "kind": "ConceptQualifier",
+                                    "valueType": "xs:string",
+                                    "type": "FormInfo"
+                                },
+                                {
+                                    "value": "refSimDocumentation'{0:00}'",
+                                    "kind": "ConceptQualifier",
+                                    "valueType": "xs:string",
+                                    "type": "PresetIdShort"
+                                },
+                                {
+                                    "value": "ZeroToMany",
+                                    "kind": "ConceptQualifier",
+                                    "valueType": "xs:string",
+                                    "type": "Multiplicity"
+                                }
+                            ],
+                            "contentType": "image/png"
+                        },
+                        {
+                            "idShort": "ModelFile",
+                            "category": "CONSTANT",
+                            "modelType": "SubmodelElementCollection",
+                            "semanticId": {
+                                "type": "ExternalReference",
+                                "keys": [
+                                    {
+                                        "type": "GlobalReference",
+                                        "value": "https://admin-shell.io/idta/SimulationModels/ModelFile/1/0"
+                                    }
+                                ]
+                            },
+                            "qualifiers": [
+                                {
+                                    "value": "modelFile",
+                                    "kind": "ConceptQualifier",
+                                    "valueType": "xs:string",
+                                    "type": "FormTitle"
+                                },
+                                {
+                                    "value": "Providing versions of the simulation model and with characteristics to distinguish them.",
+                                    "kind": "ConceptQualifier",
+                                    "valueType": "xs:string",
+                                    "type": "FormInfo"
+                                },
+                                {
+                                    "value": "modelFile",
+                                    "kind": "ConceptQualifier",
+                                    "valueType": "xs:string",
+                                    "type": "PresetIdShort"
+                                },
+                                {
+                                    "value": "One",
+                                    "kind": "ConceptQualifier",
+                                    "valueType": "xs:string",
+                                    "type": "Multiplicity"
+                                }
+                            ],
+                            "value": [
+                                {
+                                    "idShort": "ModelFileType",
+                                    "modelType": "Property",
+                                    "semanticId": {
+                                        "type": "ExternalReference",
+                                        "keys": [
+                                            {
+                                                "type": "GlobalReference",
+                                                "value": "https://admin-shell.io/idta/SimulationModels/ModelFileType/1/0"
+                                            }
+                                        ]
+                                    },
+                                    "qualifiers": [
+                                        {
+                                            "value": "modelFileType",
+                                            "kind": "ConceptQualifier",
+                                            "valueType": "xs:string",
+                                            "type": "FormTitle"
+                                        },
+                                        {
+                                            "value": "\"Designation of the exchange format of the model. E.G.: FMI 1.0, Co-Simulation, Platform / Source - Code. FMI 2.0.2, Model Exchange, Source - Code. S-function, Version 2, 64bit, mex - Format / or C-Code. Modelica 3, encoded. VHDL",
+                                            "kind": "ConceptQualifier",
+                                            "valueType": "xs:string",
+                                            "type": "FormInfo"
+                                        },
+                                        {
+                                            "value": "modelFileType",
+                                            "kind": "ConceptQualifier",
+                                            "valueType": "xs:string",
+                                            "type": "PresetIdShort"
+                                        },
+                                        {
+                                            "value": "ZeroToOne",
+                                            "kind": "ConceptQualifier",
+                                            "valueType": "xs:string",
+                                            "type": "Multiplicity"
+                                        }
+                                    ],
+                                    "valueType": "xs:string"
+                                },
+                                {
+                                    "idShort": "ModelFileVersion",
+                                    "category": "CONSTANT",
+                                    "modelType": "SubmodelElementCollection",
+                                    "semanticId": {
+                                        "type": "ExternalReference",
+                                        "keys": [
+                                            {
+                                                "type": "GlobalReference",
+                                                "value": "https://admin-shell.io/idta/SimulationModels/ModelFileVersion/1/0"
+                                            }
+                                        ]
+                                    },
+                                    "qualifiers": [
+                                        {
+                                            "value": "modelFileVersion",
+                                            "kind": "ConceptQualifier",
+                                            "valueType": "xs:string",
+                                            "type": "FormTitle"
+                                        },
+                                        {
+                                            "value": "Provision of a version of the simulation model with information to distinguish the versions. The versions are primarily intended for bug fixes without content changes.",
+                                            "kind": "ConceptQualifier",
+                                            "valueType": "xs:string",
+                                            "type": "FormInfo"
+                                        },
+                                        {
+                                            "value": "modelFileVersion'{0:00}'",
+                                            "kind": "ConceptQualifier",
+                                            "valueType": "xs:string",
+                                            "type": "PresetIdShort"
+                                        },
+                                        {
+                                            "value": "OneToMany",
+                                            "kind": "ConceptQualifier",
+                                            "valueType": "xs:string",
+                                            "type": "Multiplicity"
+                                        }
+                                    ],
+                                    "value": [
+                                        {
+                                            "idShort": "ModelVersionId",
+                                            "modelType": "Property",
+                                            "semanticId": {
+                                                "type": "ExternalReference",
+                                                "keys": [
+                                                    {
+                                                        "type": "GlobalReference",
+                                                        "value": "https://admin-shell.io/idta/SimulationModels/ModelVersionId/1/0"
+                                                    }
+                                                ]
+                                            },
+                                            "qualifiers": [
+                                                {
+                                                    "value": "modelVersionId",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "FormTitle"
+                                                },
+                                                {
+                                                    "value": "Version number of the model from the vendor.",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "FormInfo"
+                                                },
+                                                {
+                                                    "value": "modelVersionId",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "PresetIdShort"
+                                                },
+                                                {
+                                                    "value": "One",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "Multiplicity"
+                                                }
+                                            ],
+                                            "valueType": "xs:string"
+                                        },
+                                        {
+                                            "idShort": "ModelPreviewImage",
+                                            "category": "CONSTANT",
+                                            "modelType": "File",
+                                            "semanticId": {
+                                                "type": "ExternalReference",
+                                                "keys": [
+                                                    {
+                                                        "type": "GlobalReference",
+                                                        "value": "https://admin-shell.io/idta/SimulationModels/ModelPreviewImage/1/0"
+                                                    }
+                                                ]
+                                            },
+                                            "qualifiers": [
+                                                {
+                                                    "value": "modelPreviewImage",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "FormTitle"
+                                                },
+                                                {
+                                                    "value": "Image file to represent the model in user interfaces, e.g. in a search.",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "FormInfo"
+                                                },
+                                                {
+                                                    "value": "modelPreviewImage",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "PresetIdShort"
+                                                },
+                                                {
+                                                    "value": "ZeroToOne",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "Multiplicity"
+                                                }
+                                            ],
+                                            "contentType": "image/png"
+                                        },
+                                        {
+                                            "idShort": "DigitalFile",
+                                            "category": "CONSTANT",
+                                            "modelType": "File",
+                                            "semanticId": {
+                                                "type": "ExternalReference",
+                                                "keys": [
+                                                    {
+                                                        "type": "GlobalReference",
+                                                        "value": "https://admin-shell.io/idta/SimulationModels/DigitalFile/1/0"
+                                                    }
+                                                ]
+                                            },
+                                            "qualifiers": [
+                                                {
+                                                    "value": "digitalFile",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "FormTitle"
+                                                },
+                                                {
+                                                    "value": "Deployment of the model file.",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "FormInfo"
+                                                },
+                                                {
+                                                    "value": "digitalFile",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "PresetIdShort"
+                                                },
+                                                {
+                                                    "value": "One",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "Multiplicity"
+                                                }
+                                            ],
+                                            "contentType": "image/png"
+                                        },
+                                        {
+                                            "idShort": "ModelFileReleaseNotesTxt",
+                                            "modelType": "MultiLanguageProperty",
+                                            "semanticId": {
+                                                "type": "ExternalReference",
+                                                "keys": [
+                                                    {
+                                                        "type": "GlobalReference",
+                                                        "value": "https://admin-shell.io/idta/SimulationModels/ModelFileReleaseNotesTxt/1/0"
+                                                    }
+                                                ]
+                                            },
+                                            "qualifiers": [
+                                                {
+                                                    "value": "modelFileReleaseNotesTxt",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "FormTitle"
+                                                },
+                                                {
+                                                    "value": "contains information about this release",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "FormInfo"
+                                                },
+                                                {
+                                                    "value": "modelFileReleaseNotesTxt",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "PresetIdShort"
+                                                },
+                                                {
+                                                    "value": "ZeroToOne",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "Multiplicity"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "idShort": "ModelFileReleaseNotesFile",
+                                            "modelType": "File",
+                                            "semanticId": {
+                                                "type": "ExternalReference",
+                                                "keys": [
+                                                    {
+                                                        "type": "GlobalReference",
+                                                        "value": "https://admin-shell.io/idta/SimulationModels/ModelFileReleaseNotesFile/1/0"
+                                                    }
+                                                ]
+                                            },
+                                            "qualifiers": [
+                                                {
+                                                    "value": "modelFileReleaseNotesFile",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "FormTitle"
+                                                },
+                                                {
+                                                    "value": "release notes link or file",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "FormInfo"
+                                                },
+                                                {
+                                                    "value": "modelFileReleaseNotesFile",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "PresetIdShort"
+                                                },
+                                                {
+                                                    "value": "ZeroToOne",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "Multiplicity"
+                                                }
+                                            ],
+                                            "contentType": "image/png"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "idShort": "ParamMethod",
+                            "modelType": "Property",
+                            "semanticId": {
+                                "type": "ExternalReference",
+                                "keys": [
+                                    {
+                                        "type": "GlobalReference",
+                                        "value": "https://admin-shell.io/idta/SimulationModels/ParamMethod/1/0"
+                                    }
+                                ]
+                            },
+                            "qualifiers": [
+                                {
+                                    "value": "paramMethod",
+                                    "kind": "ConceptQualifier",
+                                    "valueType": "xs:string",
+                                    "type": "FormTitle"
+                                },
+                                {
+                                    "value": "Indicates whether the model must be parameterized and if so, which method is required.",
+                                    "kind": "ConceptQualifier",
+                                    "valueType": "xs:string",
+                                    "type": "FormInfo"
+                                },
+                                {
+                                    "value": "paramMethod",
+                                    "kind": "ConceptQualifier",
+                                    "valueType": "xs:string",
+                                    "type": "PresetIdShort"
+                                },
+                                {
+                                    "value": "One",
+                                    "kind": "ConceptQualifier",
+                                    "valueType": "xs:string",
+                                    "type": "Multiplicity"
+                                },
+                                {
+                                    "value": "by using \"technical data\" of asset; by using \"technical data\" and user; by user interface; by setting file; not necessary; by documentation file; pre-parametrized",
+                                    "kind": "ConceptQualifier",
+                                    "valueType": "xs:string",
+                                    "type": "FormChoices"
+                                }
+                            ],
+                            "valueType": "xs:string"
+                        },
+                        {
+                            "idShort": "ParamFile",
+                            "modelType": "File",
+                            "semanticId": {
+                                "type": "ExternalReference",
+                                "keys": [
+                                    {
+                                        "type": "GlobalReference",
+                                        "value": "https://admin-shell.io/idta/SimulationModels/ParamFile/1/0"
+                                    }
+                                ]
+                            },
+                            "qualifiers": [
+                                {
+                                    "value": "paramFile",
+                                    "kind": "ConceptQualifier",
+                                    "valueType": "xs:string",
+                                    "type": "FormTitle"
+                                },
+                                {
+                                    "value": "File for parameterization of the model. As parameter file or parameter documentation (e.g. pdf). ",
+                                    "kind": "ConceptQualifier",
+                                    "valueType": "xs:string",
+                                    "type": "FormInfo"
+                                },
+                                {
+                                    "value": "paramFile",
+                                    "kind": "ConceptQualifier",
+                                    "valueType": "xs:string",
+                                    "type": "PresetIdShort"
+                                },
+                                {
+                                    "value": "ZeroToOne",
+                                    "kind": "ConceptQualifier",
+                                    "valueType": "xs:string",
+                                    "type": "Multiplicity"
+                                }
+                            ],
+                            "contentType": "image/png"
+                        },
+                        {
+                            "idShort": "InitStateMethod",
+                            "modelType": "Property",
+                            "semanticId": {
+                                "type": "ExternalReference",
+                                "keys": [
+                                    {
+                                        "type": "GlobalReference",
+                                        "value": "https://admin-shell.io/idta/SimulationModels/InitStateMethod/1/0"
+                                    }
+                                ]
+                            },
+                            "qualifiers": [
+                                {
+                                    "value": "initStateMethod",
+                                    "kind": "ConceptQualifier",
+                                    "valueType": "xs:string",
+                                    "type": "FormTitle"
+                                },
+                                {
+                                    "value": "\" Describes the state variables of the simulation model that must be initialized to start the simulation. For initial value problems, these quantities describe the system state at the start of the simulation. In this case, the system is in a state of equilibrium. Alternatively, a simulation model may include a method to determine consistent initial values at this step, e.g., at an operating point. ",
+                                    "kind": "ConceptQualifier",
+                                    "valueType": "xs:string",
+                                    "type": "FormInfo"
+                                },
+                                {
+                                    "value": "initStateMethod",
+                                    "kind": "ConceptQualifier",
+                                    "valueType": "xs:string",
+                                    "type": "PresetIdShort"
+                                },
+                                {
+                                    "value": "One",
+                                    "kind": "ConceptQualifier",
+                                    "valueType": "xs:string",
+                                    "type": "Multiplicity"
+                                },
+                                {
+                                    "value": "not necessary, by user interface; by setting file; set states within simulation environment; integrated in model; by documentation file",
+                                    "kind": "ConceptQualifier",
+                                    "valueType": "xs:string",
+                                    "type": "FormChoices"
+                                }
+                            ],
+                            "valueType": "xs:string"
+                        },
+                        {
+                            "idShort": "InitStateFile",
+                            "modelType": "File",
+                            "semanticId": {
+                                "type": "ExternalReference",
+                                "keys": [
+                                    {
+                                        "type": "GlobalReference",
+                                        "value": "https://admin-shell.io/idta/SimulationModels/InitStateFile/1/0"
+                                    }
+                                ]
+                            },
+                            "qualifiers": [
+                                {
+                                    "value": "initStateFile",
+                                    "kind": "ConceptQualifier",
+                                    "valueType": "xs:string",
+                                    "type": "FormTitle"
+                                },
+                                {
+                                    "value": "File for parameterizing the initial states of the model. As parameter file or parameter documentation (e.g. pdf). ",
+                                    "kind": "ConceptQualifier",
+                                    "valueType": "xs:string",
+                                    "type": "FormInfo"
+                                },
+                                {
+                                    "value": "initStateFile",
+                                    "kind": "ConceptQualifier",
+                                    "valueType": "xs:string",
+                                    "type": "PresetIdShort"
+                                },
+                                {
+                                    "value": "ZeroToOne",
+                                    "kind": "ConceptQualifier",
+                                    "valueType": "xs:string",
+                                    "type": "Multiplicity"
+                                }
+                            ],
+                            "contentType": "image/png"
+                        },
+                        {
+                            "idShort": "DefaultSimTime",
+                            "modelType": "Property",
+                            "semanticId": {
+                                "type": "ExternalReference",
+                                "keys": [
+                                    {
+                                        "type": "GlobalReference",
+                                        "value": "https://admin-shell.io/idta/SimulationModels/DefaultSimTime/1/0"
+                                    }
+                                ]
+                            },
+                            "qualifiers": [
+                                {
+                                    "value": "defaultSimTime",
+                                    "kind": "ConceptQualifier",
+                                    "valueType": "xs:string",
+                                    "type": "FormTitle"
+                                },
+                                {
+                                    "value": "Predefined simulation period in seconds ",
+                                    "kind": "ConceptQualifier",
+                                    "valueType": "xs:string",
+                                    "type": "FormInfo"
+                                },
+                                {
+                                    "value": "defaultSimTime",
+                                    "kind": "ConceptQualifier",
+                                    "valueType": "xs:string",
+                                    "type": "PresetIdShort"
+                                },
+                                {
+                                    "value": "ZeroToOne",
+                                    "kind": "ConceptQualifier",
+                                    "valueType": "xs:string",
+                                    "type": "Multiplicity"
+                                }
+                            ],
+                            "valueType": "xs:float"
+                        },
+                        {
+                            "idShort": "SimModManufacturerInformation",
+                            "category": "CONSTANT",
+                            "modelType": "SubmodelElementCollection",
+                            "semanticId": {
+                                "type": "ExternalReference",
+                                "keys": [
+                                    {
+                                        "type": "GlobalReference",
+                                        "value": "https://admin-shell.io/idta/SimulationModels/SimModManufacturerInformation/1/0"
+                                    }
+                                ]
+                            },
+                            "qualifiers": [
+                                {
+                                    "value": "simModManufacturerInformation",
+                                    "kind": "ConceptQualifier",
+                                    "valueType": "xs:string",
+                                    "type": "FormTitle"
+                                },
+                                {
+                                    "value": "Provide access to  simulation support service provided by the distributor via mail or phone",
+                                    "kind": "ConceptQualifier",
+                                    "valueType": "xs:string",
+                                    "type": "FormInfo"
+                                },
+                                {
+                                    "value": "simModManufacturerInformation'{0:00}'",
+                                    "kind": "ConceptQualifier",
+                                    "valueType": "xs:string",
+                                    "type": "PresetIdShort"
+                                },
+                                {
+                                    "value": "ZeroToMany",
+                                    "kind": "ConceptQualifier",
+                                    "valueType": "xs:string",
+                                    "type": "Multiplicity"
+                                }
+                            ],
+                            "value": [
+                                {
+                                    "idShort": "Company",
+                                    "modelType": "Property",
+                                    "semanticId": {
+                                        "type": "ExternalReference",
+                                        "keys": [
+                                            {
+                                                "type": "GlobalReference",
+                                                "value": "0173-1#02-AAW001#001"
+                                            }
+                                        ]
+                                    },
+                                    "qualifiers": [
+                                        {
+                                            "value": "company",
+                                            "kind": "ConceptQualifier",
+                                            "valueType": "xs:string",
+                                            "type": "FormTitle"
+                                        },
+                                        {
+                                            "value": "name of the company",
+                                            "kind": "ConceptQualifier",
+                                            "valueType": "xs:string",
+                                            "type": "FormInfo"
+                                        },
+                                        {
+                                            "value": "company",
+                                            "kind": "ConceptQualifier",
+                                            "valueType": "xs:string",
+                                            "type": "PresetIdShort"
+                                        },
+                                        {
+                                            "value": "One",
+                                            "kind": "ConceptQualifier",
+                                            "valueType": "xs:string",
+                                            "type": "Multiplicity"
+                                        }
+                                    ],
+                                    "valueType": "xs:string"
+                                },
+                                {
+                                    "idShort": "Language",
+                                    "modelType": "Property",
+                                    "semanticId": {
+                                        "type": "ExternalReference",
+                                        "keys": [
+                                            {
+                                                "type": "GlobalReference",
+                                                "value": "0173-1#02-AAO895#003"
+                                            }
+                                        ]
+                                    },
+                                    "qualifiers": [
+                                        {
+                                            "value": "language",
+                                            "kind": "ConceptQualifier",
+                                            "valueType": "xs:string",
+                                            "type": "FormTitle"
+                                        },
+                                        {
+                                            "value": "available language",
+                                            "kind": "ConceptQualifier",
+                                            "valueType": "xs:string",
+                                            "type": "FormInfo"
+                                        },
+                                        {
+                                            "value": "language'{0:00}'",
+                                            "kind": "ConceptQualifier",
+                                            "valueType": "xs:string",
+                                            "type": "PresetIdShort"
+                                        },
+                                        {
+                                            "value": "OneToMany",
+                                            "kind": "ConceptQualifier",
+                                            "valueType": "xs:string",
+                                            "type": "Multiplicity"
+                                        }
+                                    ],
+                                    "valueType": "xs:string"
+                                },
+                                {
+                                    "idShort": "Email",
+                                    "modelType": "SubmodelElementCollection",
+                                    "semanticId": {
+                                        "type": "ExternalReference",
+                                        "keys": [
+                                            {
+                                                "type": "GlobalReference",
+                                                "value": "0173-1#02-AAQ836#005"
+                                            }
+                                        ]
+                                    },
+                                    "qualifiers": [
+                                        {
+                                            "value": "email",
+                                            "kind": "ConceptQualifier",
+                                            "valueType": "xs:string",
+                                            "type": "FormTitle"
+                                        },
+                                        {
+                                            "value": "E-mail address and encryption method",
+                                            "kind": "ConceptQualifier",
+                                            "valueType": "xs:string",
+                                            "type": "FormInfo"
+                                        },
+                                        {
+                                            "value": "email",
+                                            "kind": "ConceptQualifier",
+                                            "valueType": "xs:string",
+                                            "type": "PresetIdShort"
+                                        },
+                                        {
+                                            "value": "ZeroToOne",
+                                            "kind": "ConceptQualifier",
+                                            "valueType": "xs:string",
+                                            "type": "Multiplicity"
+                                        }
+                                    ],
+                                    "value": [
+                                        {
+                                            "idShort": "TypeOfEmailAddress",
+                                            "modelType": "Property",
+                                            "semanticId": {
+                                                "type": "ExternalReference",
+                                                "keys": [
+                                                    {
+                                                        "type": "GlobalReference",
+                                                        "value": "0173-1#02-AAO199#003"
+                                                    }
+                                                ]
+                                            },
+                                            "qualifiers": [
+                                                {
+                                                    "value": "typeOfEmailAddress",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "FormTitle"
+                                                },
+                                                {
+                                                    "value": "characterization of an e-mail address according to its location or usage",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "FormInfo"
+                                                },
+                                                {
+                                                    "value": "typeOfEmailAddress",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "PresetIdShort"
+                                                },
+                                                {
+                                                    "value": "ZeroToOne",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "Multiplicity"
+                                                }
+                                            ],
+                                            "valueType": "xs:string"
+                                        },
+                                        {
+                                            "idShort": "EmailAddress",
+                                            "modelType": "Property",
+                                            "semanticId": {
+                                                "type": "ExternalReference",
+                                                "keys": [
+                                                    {
+                                                        "type": "GlobalReference",
+                                                        "value": "0173-1#02-AAO198#002"
+                                                    }
+                                                ]
+                                            },
+                                            "qualifiers": [
+                                                {
+                                                    "value": "emailAddress",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "FormTitle"
+                                                },
+                                                {
+                                                    "value": "electronic mail address of a business partner",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "FormInfo"
+                                                },
+                                                {
+                                                    "value": "emailAddress",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "PresetIdShort"
+                                                },
+                                                {
+                                                    "value": "One",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "Multiplicity"
+                                                }
+                                            ],
+                                            "valueType": "xs:string"
+                                        },
+                                        {
+                                            "idShort": "TypeOfPublicKey",
+                                            "modelType": "Property",
+                                            "semanticId": {
+                                                "type": "ExternalReference",
+                                                "keys": [
+                                                    {
+                                                        "type": "GlobalReference",
+                                                        "value": "0173-1#02-AAO201#002"
+                                                    }
+                                                ]
+                                            },
+                                            "qualifiers": [
+                                                {
+                                                    "value": "typeOfPublicKey",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "FormTitle"
+                                                },
+                                                {
+                                                    "value": "characterization of a public key according to its encryption process",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "FormInfo"
+                                                },
+                                                {
+                                                    "value": "typeOfPublicKey",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "PresetIdShort"
+                                                },
+                                                {
+                                                    "value": "ZeroToOne",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "Multiplicity"
+                                                }
+                                            ],
+                                            "valueType": "xs:string"
+                                        },
+                                        {
+                                            "idShort": "PublicKey",
+                                            "modelType": "Property",
+                                            "semanticId": {
+                                                "type": "ExternalReference",
+                                                "keys": [
+                                                    {
+                                                        "type": "GlobalReference",
+                                                        "value": "0173-1#02-AAO200#002"
+                                                    }
+                                                ]
+                                            },
+                                            "qualifiers": [
+                                                {
+                                                    "value": "publicKey",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "FormTitle"
+                                                },
+                                                {
+                                                    "value": "public part of an unsymmetrical key pair to sign or encrypt text or messages",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "FormInfo"
+                                                },
+                                                {
+                                                    "value": "publicKey",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "PresetIdShort"
+                                                },
+                                                {
+                                                    "value": "ZeroToOne",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "Multiplicity"
+                                                }
+                                            ],
+                                            "valueType": "xs:string"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "idShort": "Phone",
+                                    "modelType": "SubmodelElementCollection",
+                                    "semanticId": {
+                                        "type": "ExternalReference",
+                                        "keys": [
+                                            {
+                                                "type": "GlobalReference",
+                                                "value": "https://admin-shell.io/zvei/nameplate/1/0/ContactInformations/ContactInformation/Phone"
+                                            }
+                                        ]
+                                    },
+                                    "qualifiers": [
+                                        {
+                                            "value": "phone",
+                                            "kind": "ConceptQualifier",
+                                            "valueType": "xs:string",
+                                            "type": "FormTitle"
+                                        },
+                                        {
+                                            "value": "Phone number including type",
+                                            "kind": "ConceptQualifier",
+                                            "valueType": "xs:string",
+                                            "type": "FormInfo"
+                                        },
+                                        {
+                                            "value": "phone",
+                                            "kind": "ConceptQualifier",
+                                            "valueType": "xs:string",
+                                            "type": "PresetIdShort"
+                                        },
+                                        {
+                                            "value": "ZeroToOne",
+                                            "kind": "ConceptQualifier",
+                                            "valueType": "xs:string",
+                                            "type": "Multiplicity"
+                                        }
+                                    ],
+                                    "value": [
+                                        {
+                                            "idShort": "TypeOfTelephone",
+                                            "modelType": "Property",
+                                            "semanticId": {
+                                                "type": "ExternalReference",
+                                                "keys": [
+                                                    {
+                                                        "type": "GlobalReference",
+                                                        "value": "0173-1#02-AAO137#003"
+                                                    }
+                                                ]
+                                            },
+                                            "qualifiers": [
+                                                {
+                                                    "value": "typeOfTelephone",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "FormTitle"
+                                                },
+                                                {
+                                                    "value": "characterization of a telephone according to its location or usage",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "FormInfo"
+                                                },
+                                                {
+                                                    "value": "typeOfTelephone",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "PresetIdShort"
+                                                },
+                                                {
+                                                    "value": "ZeroToOne",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "Multiplicity"
+                                                }
+                                            ],
+                                            "valueType": "xs:string"
+                                        },
+                                        {
+                                            "idShort": "TelephoneNumber",
+                                            "modelType": "Property",
+                                            "semanticId": {
+                                                "type": "ExternalReference",
+                                                "keys": [
+                                                    {
+                                                        "type": "GlobalReference",
+                                                        "value": "0173-1#02-AAO136#002"
+                                                    }
+                                                ]
+                                            },
+                                            "qualifiers": [
+                                                {
+                                                    "value": "telephoneNumber",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "FormTitle"
+                                                },
+                                                {
+                                                    "value": "complete telephone number to be called to reach a business partner",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "FormInfo"
+                                                },
+                                                {
+                                                    "value": "telephoneNumber",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "PresetIdShort"
+                                                },
+                                                {
+                                                    "value": "One",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "Multiplicity"
+                                                }
+                                            ],
+                                            "valueType": "xs:string"
+                                        },
+                                        {
+                                            "idShort": "AvailableTime",
+                                            "modelType": "Property",
+                                            "semanticId": {
+                                                "type": "ExternalReference",
+                                                "keys": [
+                                                    {
+                                                        "type": "GlobalReference",
+                                                        "value": "https://admin-shell.io/zvei/nameplate/1/0/ContactInformations/ContactInformation/AvailableTime/"
+                                                    }
+                                                ]
+                                            },
+                                            "qualifiers": [
+                                                {
+                                                    "value": "availableTime",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "FormTitle"
+                                                },
+                                                {
+                                                    "value": "Specification of the available time window",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "FormInfo"
+                                                },
+                                                {
+                                                    "value": "availableTime",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "PresetIdShort"
+                                                },
+                                                {
+                                                    "value": "ZeroToOne",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "Multiplicity"
+                                                }
+                                            ],
+                                            "valueType": "xs:string"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "idShort": "Ports",
+                            "modelType": "SubmodelElementCollection",
+                            "semanticId": {
+                                "type": "ExternalReference",
+                                "keys": [
+                                    {
+                                        "type": "GlobalReference",
+                                        "value": "https://admin-shell.io/idta/SimulationModels/Ports/1/0"
+                                    }
+                                ]
+                            },
+                            "qualifiers": [
+                                {
+                                    "value": "ports",
+                                    "kind": "ConceptQualifier",
+                                    "valueType": "xs:string",
+                                    "type": "FormTitle"
+                                },
+                                {
+                                    "value": "Interfaces of the model. This includes inputs, outputs as well as acausal connections (e.g. mechanical connections). In addition, it is specified here whether the model provides binary interfaces (e.g. for visualization).",
+                                    "kind": "ConceptQualifier",
+                                    "valueType": "xs:string",
+                                    "type": "FormInfo"
+                                },
+                                {
+                                    "value": "ports",
+                                    "kind": "ConceptQualifier",
+                                    "valueType": "xs:string",
+                                    "type": "PresetIdShort"
+                                },
+                                {
+                                    "value": "ZeroToOne",
+                                    "kind": "ConceptQualifier",
+                                    "valueType": "xs:string",
+                                    "type": "Multiplicity"
+                                }
+                            ],
+                            "value": [
+                                {
+                                    "idShort": "PortsConnector",
+                                    "modelType": "SubmodelElementCollection",
+                                    "semanticId": {
+                                        "type": "ExternalReference",
+                                        "keys": [
+                                            {
+                                                "type": "GlobalReference",
+                                                "value": "https://admin-shell.io/idta/SimulationModels/PortsConnector/1/0"
+                                            }
+                                        ]
+                                    },
+                                    "qualifiers": [
+                                        {
+                                            "value": "portsConnector",
+                                            "kind": "ConceptQualifier",
+                                            "valueType": "xs:string",
+                                            "type": "FormTitle"
+                                        },
+                                        {
+                                            "value": "List of ports of the model. These include a name, a description, a list of variables, and a list of ports.",
+                                            "kind": "ConceptQualifier",
+                                            "valueType": "xs:string",
+                                            "type": "FormInfo"
+                                        },
+                                        {
+                                            "value": "portsConnector'{0:00}'",
+                                            "kind": "ConceptQualifier",
+                                            "valueType": "xs:string",
+                                            "type": "PresetIdShort"
+                                        },
+                                        {
+                                            "value": "ZeroToMany",
+                                            "kind": "ConceptQualifier",
+                                            "valueType": "xs:string",
+                                            "type": "Multiplicity"
+                                        }
+                                    ],
+                                    "value": [
+                                        {
+                                            "idShort": "PortConnectorName",
+                                            "modelType": "Property",
+                                            "semanticId": {
+                                                "type": "ExternalReference",
+                                                "keys": [
+                                                    {
+                                                        "type": "GlobalReference",
+                                                        "value": "https://admin-shell.io/idta/SimulationModels/PortsConnectorName/1/0"
+                                                    }
+                                                ]
+                                            },
+                                            "qualifiers": [
+                                                {
+                                                    "value": "portConnectorName",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "FormTitle"
+                                                },
+                                                {
+                                                    "value": "Name of the Connector Port.",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "FormInfo"
+                                                },
+                                                {
+                                                    "value": "portConnectorName",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "PresetIdShort"
+                                                },
+                                                {
+                                                    "value": "One",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "Multiplicity"
+                                                }
+                                            ],
+                                            "valueType": "xs:string"
+                                        },
+                                        {
+                                            "idShort": "PortConDescription",
+                                            "modelType": "MultiLanguageProperty",
+                                            "semanticId": {
+                                                "type": "ExternalReference",
+                                                "keys": [
+                                                    {
+                                                        "type": "GlobalReference",
+                                                        "value": "https://admin-shell.io/idta/SimulationModel/portConDescription/1/0"
+                                                    }
+                                                ]
+                                            },
+                                            "qualifiers": [
+                                                {
+                                                    "value": "portConDescription",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "FormTitle"
+                                                },
+                                                {
+                                                    "value": "Description of the Connector Port.",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "FormInfo"
+                                                },
+                                                {
+                                                    "value": "portConDescription",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "PresetIdShort"
+                                                },
+                                                {
+                                                    "value": "ZeroToOne",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "Multiplicity"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "idShort": "Variable",
+                                            "modelType": "SubmodelElementCollection",
+                                            "semanticId": {
+                                                "type": "ExternalReference",
+                                                "keys": [
+                                                    {
+                                                        "type": "GlobalReference",
+                                                        "value": "https://admin-shell.io/idta/SimulationModels/Variable/1/0"
+                                                    }
+                                                ]
+                                            },
+                                            "qualifiers": [
+                                                {
+                                                    "value": "variable",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "FormTitle"
+                                                },
+                                                {
+                                                    "value": "List of variables of the port.",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "FormInfo"
+                                                },
+                                                {
+                                                    "value": "variable{0:00}",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "PresetIdShort"
+                                                },
+                                                {
+                                                    "value": "ZeroToMany",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "Multiplicity"
+                                                }
+                                            ],
+                                            "value": [
+                                                {
+                                                    "idShort": "VariableName",
+                                                    "modelType": "Property",
+                                                    "semanticId": {
+                                                        "type": "ExternalReference",
+                                                        "keys": [
+                                                            {
+                                                                "type": "GlobalReference",
+                                                                "value": "https://admin-shell.io/idta/SimulationModels/VariableName/1/0"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "qualifiers": [
+                                                        {
+                                                            "value": "variableName",
+                                                            "kind": "ConceptQualifier",
+                                                            "valueType": "xs:string",
+                                                            "type": "FormTitle"
+                                                        },
+                                                        {
+                                                            "value": "Name of the variable.",
+                                                            "kind": "ConceptQualifier",
+                                                            "valueType": "xs:string",
+                                                            "type": "FormInfo"
+                                                        },
+                                                        {
+                                                            "value": "variableName",
+                                                            "kind": "ConceptQualifier",
+                                                            "valueType": "xs:string",
+                                                            "type": "PresetIdShort"
+                                                        },
+                                                        {
+                                                            "value": "One",
+                                                            "kind": "ConceptQualifier",
+                                                            "valueType": "xs:string",
+                                                            "type": "Multiplicity"
+                                                        }
+                                                    ],
+                                                    "valueType": "xs:string"
+                                                },
+                                                {
+                                                    "idShort": "Range",
+                                                    "modelType": "Property",
+                                                    "semanticId": {
+                                                        "type": "ExternalReference",
+                                                        "keys": [
+                                                            {
+                                                                "type": "GlobalReference",
+                                                                "value": "https://admin-shell.io/idta/SimulationModels/Range/1/0"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "qualifiers": [
+                                                        {
+                                                            "value": "range",
+                                                            "kind": "ConceptQualifier",
+                                                            "valueType": "xs:string",
+                                                            "type": "FormTitle"
+                                                        },
+                                                        {
+                                                            "value": "Range of values for the variable (e.g. [min, max], [min, max[, ]min, max], ]min, max[, {val1, val2, ...}).",
+                                                            "kind": "ConceptQualifier",
+                                                            "valueType": "xs:string",
+                                                            "type": "FormInfo"
+                                                        },
+                                                        {
+                                                            "value": "range",
+                                                            "kind": "ConceptQualifier",
+                                                            "valueType": "xs:string",
+                                                            "type": "PresetIdShort"
+                                                        },
+                                                        {
+                                                            "value": "ZeroToOne",
+                                                            "kind": "ConceptQualifier",
+                                                            "valueType": "xs:string",
+                                                            "type": "Multiplicity"
+                                                        }
+                                                    ],
+                                                    "valueType": "xs:string"
+                                                },
+                                                {
+                                                    "idShort": "VariableType",
+                                                    "modelType": "Property",
+                                                    "semanticId": {
+                                                        "type": "ExternalReference",
+                                                        "keys": [
+                                                            {
+                                                                "type": "GlobalReference",
+                                                                "value": "https://admin-shell.io/idta/SimulationModels/VariableType/1/0"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "qualifiers": [
+                                                        {
+                                                            "value": "variableType",
+                                                            "kind": "ConceptQualifier",
+                                                            "valueType": "xs:string",
+                                                            "type": "FormTitle"
+                                                        },
+                                                        {
+                                                            "value": "Type of the variable (e.g. Real, Integer, Boolean, String or Enum).",
+                                                            "kind": "ConceptQualifier",
+                                                            "valueType": "xs:string",
+                                                            "type": "FormInfo"
+                                                        },
+                                                        {
+                                                            "value": "variableType",
+                                                            "kind": "ConceptQualifier",
+                                                            "valueType": "xs:string",
+                                                            "type": "PresetIdShort"
+                                                        },
+                                                        {
+                                                            "value": "One",
+                                                            "kind": "ConceptQualifier",
+                                                            "valueType": "xs:string",
+                                                            "type": "Multiplicity"
+                                                        },
+                                                        {
+                                                            "value": "Real; Integer; Boolean; String; ENUM",
+                                                            "kind": "ConceptQualifier",
+                                                            "valueType": "xs:string",
+                                                            "type": "FormChoices"
+                                                        }
+                                                    ],
+                                                    "valueType": "xs:string"
+                                                },
+                                                {
+                                                    "idShort": "VariableDescription",
+                                                    "modelType": "MultiLanguageProperty",
+                                                    "semanticId": {
+                                                        "type": "ExternalReference",
+                                                        "keys": [
+                                                            {
+                                                                "type": "GlobalReference",
+                                                                "value": "https://admin-shell.io/idta/SimulationModels/VariableDescription/1/0"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "qualifiers": [
+                                                        {
+                                                            "value": "variableDescription",
+                                                            "kind": "ConceptQualifier",
+                                                            "valueType": "xs:string",
+                                                            "type": "FormTitle"
+                                                        },
+                                                        {
+                                                            "value": "Description of the variable.",
+                                                            "kind": "ConceptQualifier",
+                                                            "valueType": "xs:string",
+                                                            "type": "FormInfo"
+                                                        },
+                                                        {
+                                                            "value": "variableDescription",
+                                                            "kind": "ConceptQualifier",
+                                                            "valueType": "xs:string",
+                                                            "type": "PresetIdShort"
+                                                        },
+                                                        {
+                                                            "value": "ZeroToOne",
+                                                            "kind": "ConceptQualifier",
+                                                            "valueType": "xs:string",
+                                                            "type": "Multiplicity"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "idShort": "UnitList",
+                                                    "modelType": "Property",
+                                                    "semanticId": {
+                                                        "type": "ExternalReference",
+                                                        "keys": [
+                                                            {
+                                                                "type": "GlobalReference",
+                                                                "value": "https://admin-shell.io/idta/SimulationModels/UnitList/1/0"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "qualifiers": [
+                                                        {
+                                                            "value": "unitList",
+                                                            "kind": "ConceptQualifier",
+                                                            "valueType": "xs:string",
+                                                            "type": "FormTitle"
+                                                        },
+                                                        {
+                                                            "value": "The most common units can be selected here. .. If \"others\" is selected, a free text can be entered.",
+                                                            "kind": "ConceptQualifier",
+                                                            "valueType": "xs:string",
+                                                            "type": "FormInfo"
+                                                        },
+                                                        {
+                                                            "value": "unitList",
+                                                            "kind": "ConceptQualifier",
+                                                            "valueType": "xs:string",
+                                                            "type": "PresetIdShort"
+                                                        },
+                                                        {
+                                                            "value": "One",
+                                                            "kind": "ConceptQualifier",
+                                                            "valueType": "xs:string",
+                                                            "type": "Multiplicity"
+                                                        },
+                                                        {
+                                                            "value": "s; m; kg; N; m/s; m/s^2; V; A; K; none",
+                                                            "kind": "ConceptQualifier",
+                                                            "valueType": "xs:string",
+                                                            "type": "FormChoices"
+                                                        }
+                                                    ],
+                                                    "valueType": "xs:string"
+                                                },
+                                                {
+                                                    "idShort": "UnitDescription",
+                                                    "modelType": "MultiLanguageProperty",
+                                                    "semanticId": {
+                                                        "type": "ExternalReference",
+                                                        "keys": [
+                                                            {
+                                                                "type": "GlobalReference",
+                                                                "value": "https://admin-shell.io/idta/SimulationModels/UnitDescription/1/0"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "qualifiers": [
+                                                        {
+                                                            "value": "unitDescription",
+                                                            "kind": "ConceptQualifier",
+                                                            "valueType": "xs:string",
+                                                            "type": "FormTitle"
+                                                        },
+                                                        {
+                                                            "value": "Text field for missing units of the list.",
+                                                            "kind": "ConceptQualifier",
+                                                            "valueType": "xs:string",
+                                                            "type": "FormInfo"
+                                                        },
+                                                        {
+                                                            "value": "unitDescription",
+                                                            "kind": "ConceptQualifier",
+                                                            "valueType": "xs:string",
+                                                            "type": "PresetIdShort"
+                                                        },
+                                                        {
+                                                            "value": "ZeroToOne",
+                                                            "kind": "ConceptQualifier",
+                                                            "valueType": "xs:string",
+                                                            "type": "Multiplicity"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "idShort": "VariableCausality",
+                                                    "modelType": "Property",
+                                                    "semanticId": {
+                                                        "type": "ExternalReference",
+                                                        "keys": [
+                                                            {
+                                                                "type": "GlobalReference",
+                                                                "value": "https://admin-shell.io/idta/SimulationModels/VariableCausality/1/0"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "qualifiers": [
+                                                        {
+                                                            "value": "variableCausality",
+                                                            "kind": "ConceptQualifier",
+                                                            "valueType": "xs:string",
+                                                            "type": "FormTitle"
+                                                        },
+                                                        {
+                                                            "value": "The causality of the variable: input to inputs, output to ouputs, acausal connections (e.g. mechanical connection) do not have causality.",
+                                                            "kind": "ConceptQualifier",
+                                                            "valueType": "xs:string",
+                                                            "type": "FormInfo"
+                                                        },
+                                                        {
+                                                            "value": "variableCausality",
+                                                            "kind": "ConceptQualifier",
+                                                            "valueType": "xs:string",
+                                                            "type": "PresetIdShort"
+                                                        },
+                                                        {
+                                                            "value": "One",
+                                                            "kind": "ConceptQualifier",
+                                                            "valueType": "xs:string",
+                                                            "type": "Multiplicity"
+                                                        },
+                                                        {
+                                                            "value": "input; output; acausal",
+                                                            "kind": "ConceptQualifier",
+                                                            "valueType": "xs:string",
+                                                            "type": "FormChoices"
+                                                        }
+                                                    ],
+                                                    "valueType": "xs:string"
+                                                },
+                                                {
+                                                    "idShort": "VariablePrefix",
+                                                    "modelType": "Property",
+                                                    "semanticId": {
+                                                        "type": "ExternalReference",
+                                                        "keys": [
+                                                            {
+                                                                "type": "GlobalReference",
+                                                                "value": "https://admin-shell.io/idta/SimulationModels/VariablePrefix/1/0"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "qualifiers": [
+                                                        {
+                                                            "value": "variablePrefix",
+                                                            "kind": "ConceptQualifier",
+                                                            "valueType": "xs:string",
+                                                            "type": "FormTitle"
+                                                        },
+                                                        {
+                                                            "value": "Prefix for acausal variable. Potential variables are set equal when connecting (no prefix). Stream variables are connected according to Kirchhoff's law, i.e. the sum of the variables equals zero. The bi-directional flow of matter is described with \"stream\" (e.g. for enthalpy).",
+                                                            "kind": "ConceptQualifier",
+                                                            "valueType": "xs:string",
+                                                            "type": "FormInfo"
+                                                        },
+                                                        {
+                                                            "value": "variablePrefix",
+                                                            "kind": "ConceptQualifier",
+                                                            "valueType": "xs:string",
+                                                            "type": "PresetIdShort"
+                                                        },
+                                                        {
+                                                            "value": "ZeroToOne",
+                                                            "kind": "ConceptQualifier",
+                                                            "valueType": "xs:string",
+                                                            "type": "Multiplicity"
+                                                        },
+                                                        {
+                                                            "value": "Flow; Stream",
+                                                            "kind": "ConceptQualifier",
+                                                            "valueType": "xs:string",
+                                                            "type": "FormChoices"
+                                                        }
+                                                    ],
+                                                    "valueType": "xs:string"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "idShort": "BinaryConnector",
+                                    "modelType": "SubmodelElementCollection",
+                                    "semanticId": {
+                                        "type": "ExternalReference",
+                                        "keys": [
+                                            {
+                                                "type": "GlobalReference",
+                                                "value": "https://admin-shell.io/idta/SimulationModels/BinaryConnector/1/0"
+                                            }
+                                        ]
+                                    },
+                                    "qualifiers": [
+                                        {
+                                            "value": "binaryConnector",
+                                            "kind": "ConceptQualifier",
+                                            "valueType": "xs:string",
+                                            "type": "FormTitle"
+                                        },
+                                        {
+                                            "value": "Binary interfaces (binaryType) based on the FMI 3.0 standard (https://fmi-standard.org/docs/3.0-dev/#definition-of-types). At this point the name (e.g. \"Binary interface visualization\") and the description (e.g. \"Interface for binary transfer of visualization information\") are specified.",
+                                            "kind": "ConceptQualifier",
+                                            "valueType": "xs:string",
+                                            "type": "FormInfo"
+                                        },
+                                        {
+                                            "value": "binaryConnector'{0:00}'",
+                                            "kind": "ConceptQualifier",
+                                            "valueType": "xs:string",
+                                            "type": "PresetIdShort"
+                                        },
+                                        {
+                                            "value": "ZeroToMany",
+                                            "kind": "ConceptQualifier",
+                                            "valueType": "xs:string",
+                                            "type": "Multiplicity"
+                                        }
+                                    ],
+                                    "value": [
+                                        {
+                                            "idShort": "BinaryConName",
+                                            "modelType": "Property",
+                                            "semanticId": {
+                                                "type": "ExternalReference",
+                                                "keys": [
+                                                    {
+                                                        "type": "GlobalReference",
+                                                        "value": "https://admin-shell.io/idta/SimulationModels/BinaryConnectorName/1/0"
+                                                    }
+                                                ]
+                                            },
+                                            "qualifiers": [
+                                                {
+                                                    "value": "binaryConName",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "FormTitle"
+                                                },
+                                                {
+                                                    "value": "Binary interface name.",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "FormInfo"
+                                                },
+                                                {
+                                                    "value": "binConName",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "PresetIdShort"
+                                                },
+                                                {
+                                                    "value": "One",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "Multiplicity"
+                                                }
+                                            ],
+                                            "valueType": "xs:string"
+                                        },
+                                        {
+                                            "idShort": "BinaryConDescription",
+                                            "modelType": "MultiLanguageProperty",
+                                            "semanticId": {
+                                                "type": "ExternalReference",
+                                                "keys": [
+                                                    {
+                                                        "type": "GlobalReference",
+                                                        "value": "https://admin-shell.io/idta/SimulationModels/BinaryConDescription/1/0"
+                                                    }
+                                                ]
+                                            },
+                                            "qualifiers": [
+                                                {
+                                                    "value": "binaryConDescription",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "FormTitle"
+                                                },
+                                                {
+                                                    "value": "Binary interface description.",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "FormInfo"
+                                                },
+                                                {
+                                                    "value": "binaryConDescription",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "PresetIdShort"
+                                                },
+                                                {
+                                                    "value": "ZeroToOne",
+                                                    "kind": "ConceptQualifier",
+                                                    "valueType": "xs:string",
+                                                    "type": "Multiplicity"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "conceptDescriptions": [
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "tbd"
+                            },
+                            {
+                                "language": "de",
+                                "text": "tbd"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "Providing versions of the simulation model and with characteristics to distinguish them."
+                            },
+                            {
+                                "language": "de",
+                                "text": "Bereitstellung von Versionen des Simulationsmodells und mit Merkmalen zur Unterscheidung."
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "ModelFile"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "modelFile",
+            "modelType": "ConceptDescription",
+            "id": "https://admin-shell.io/idta/SimulationModels/ModelFile/1/0"
         },
         {
-          "kind": "ConceptQualifier",
-          "type": "FormInfo",
-          "valueType": "xs:string",
-          "value": "Das Submodel kann ein oder meherer Simulationsmodelle bereitstellen, einen Service zur Generierung eines spezifischen Modells oder einen Zugang zu einer offenen oder spezifischen Anfrage."
-        }
-      ],
-      "submodelElements": [
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "tbd"
+                            },
+                            {
+                                "language": "de",
+                                "text": "tbd"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "Provision of a version of the simulation model with information to distinguish the versions. The versions are primarily intended for bug fixes without content changes."
+                            },
+                            {
+                                "language": "de",
+                                "text": "Bereitstellung einer Version des Simulationsmodells mit Informationen zur Unterscheidung der Versionen. Die Versionen sind in erster Linie f\u00fcr Fehlerbehebungen gedacht ohne inhaltliche \u00c4nderungen. "
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "ModelFileVersion"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "modelFileVersion",
+            "modelType": "ConceptDescription",
+            "id": "https://admin-shell.io/idta/SimulationModels/ModelFileVersion/1/0"
+        },
         {
-          "category": "CONSTANT",
-          "idShort": "SimulationModel",
-          "semanticId": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "https://admin-shell.io/idta/SimulationModels/SimulationModel/1/0"
-              }
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "tbd"
+                            },
+                            {
+                                "language": "de",
+                                "text": "tbd"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "contains information about this release"
+                            },
+                            {
+                                "language": "de",
+                                "text": "Informationen oder hinweise zu diesem Release"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "modelFileReleaseNotesTxt",
+            "modelType": "ConceptDescription",
+            "id": "https://admin-shell.io/idta/SimulationModels/ModelFileReleaseNotesTxt/1/0"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "tbd"
+                            },
+                            {
+                                "language": "de",
+                                "text": "tbd"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "Version number of the model from the vendor."
+                            },
+                            {
+                                "language": "de",
+                                "text": "Versionnummer des Modells vom Herstellers."
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "ModelVersionId"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "modelVersionId",
+            "modelType": "ConceptDescription",
+            "id": "https://admin-shell.io/idta/SimulationModels/ModelVersionId/1/0"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "tbd"
+                            },
+                            {
+                                "language": "de",
+                                "text": "tbd"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "Deployment of the model file."
+                            },
+                            {
+                                "language": "de",
+                                "text": "Bereitstellung der Model-Datei."
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "DigitalFile"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "digitalFile",
+            "modelType": "ConceptDescription",
+            "id": "https://admin-shell.io/idta/SimulationModels/DigitalFile/1/0"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "tbd"
+                            },
+                            {
+                                "language": "de",
+                                "text": "tbd"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "Image file to represent the model in user interfaces, e.g. in a search."
+                            },
+                            {
+                                "language": "de",
+                                "text": "Bilddatei zur Repr\u00e4sentation des Modells in Oberfl\u00e4chen wie z.B. in einer Suche."
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "ModelPreviewImage"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "modelPreviewImage",
+            "modelType": "ConceptDescription",
+            "id": "https://admin-shell.io/idta/SimulationModels/ModelPreviewImage/1/0"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "Content summary"
+                            },
+                            {
+                                "language": "de",
+                                "text": "Inhaltliche Zusammenfassung"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "Summary of the contents of the simulation model in text form. "
+                            },
+                            {
+                                "language": "de",
+                                "text": "Textliche Zusammenfassung des Inhalts des Simulationsmodells. "
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "Summary"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "summary",
+            "modelType": "ConceptDescription",
+            "id": "https://admin-shell.io/idta/SimulationModels/Summary/0/1"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "tbd"
+                            },
+                            {
+                                "language": "de",
+                                "text": "tbd"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "Indicates whether the model must be parameterized and if so, which method is required."
+                            },
+                            {
+                                "language": "de",
+                                "text": "Beschreibt, ob das Modell parametriert werden muss und wenn ja, welche Methode bereit gestellt wird."
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "ParamMethod"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "paramMethod",
+            "modelType": "ConceptDescription",
+            "id": "https://admin-shell.io/idta/SimulationModels/ParamMethod/1/0"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "tbd"
+                            },
+                            {
+                                "language": "de",
+                                "text": "tbd"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "File for parameterization of the model. As parameter file or parameter documentation (e.g. pdf). "
+                            },
+                            {
+                                "language": "de",
+                                "text": "Datei zur Parametrierung des Modells. Als Parameterdatei oder Parameterdokumentation (z.B. pdf). "
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "ParamFile"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "paramFile",
+            "modelType": "ConceptDescription",
+            "id": "https://admin-shell.io/idta/SimulationModels/ParamFile/1/0"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "tbd"
+                            },
+                            {
+                                "language": "de",
+                                "text": "tbd"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "\" Describes the state variables of the simulation model that must be initialized to start the simulation. For initial value problems, these quantities describe the system state at the start of the simulation. In this case, the system is in a state of equilibrium. Alternatively, a simulation model may include a method to determine consistent initial values at this step, e.g., at an operating point. "
+                            },
+                            {
+                                "language": "de",
+                                "text": "\"Beschreibt die Zustandgr\u00f6\u00dfen des Simulationsmodels, die zum Start der Simulation initialisiert werden m\u00fcssen. Bei Anfangswertproblemen beschreiben diese Gr\u00f6\u00dfen den Systemzustand zum Beginn der Simulation. Das System befindet sich dabei in einem Gleichgewichtszustand. Alternativ kann ein Simulationsmodell eine Methode beinhalten, die in diesem Schritt konsistente Anfangswerte z. B. in einem Betriebspunkt ermittelt. "
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "InitStateMethod"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "initStateMethod",
+            "modelType": "ConceptDescription",
+            "id": "https://admin-shell.io/idta/SimulationModels/InitStateMethod/1/0"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "tbd"
+                            },
+                            {
+                                "language": "de",
+                                "text": "tbd"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "File for parameterizing the initial states of the model. As parameter file or parameter documentation (e.g. pdf). "
+                            },
+                            {
+                                "language": "de",
+                                "text": "Datei zur Parametrierung der Anfangszust\u00e4nde des Modells. Als Parameterdatei oder Parameterdokumentation (z.B. pdf). "
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "InitStateFile"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "initStateFile",
+            "modelType": "ConceptDescription",
+            "id": "https://admin-shell.io/idta/SimulationModels/InitStateFile/1/0"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "Reference Simulation Documentation"
+                            },
+                            {
+                                "language": "de",
+                                "text": "Referenz Simulation Dokumentation"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "Documentation of example simulations of the model can be supplied. This includes a solver setup and sample circuit and sample results. e.g. zip file, PDF, html, ..."
+                            },
+                            {
+                                "language": "de",
+                                "text": "\"Es kann die Dokumentationen von Beispielsimulationen des Modells mitgeliefert werden. Dieses beinhaltet eine Solvereinstellung und eine Beispielbeschaltung und Beispielergebnisse. z.B. zip-Datei, PDF, html, \u2026"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "refSimDocumentation",
+            "modelType": "ConceptDescription",
+            "id": "https://admin-shell.io/idta/SimulationModels/RefSimDocumentation/1/0"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "SimulationModel"
+                            },
+                            {
+                                "language": "de",
+                                "text": "Simulationmodell"
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "SimulationModel"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "SimulationModel",
+            "modelType": "ConceptDescription",
+            "id": "https://admin-shell.io/idta/SimulationModels/SimulationModel/1/0"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "tbd"
+                            },
+                            {
+                                "language": "de",
+                                "text": "tbd"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "If a simulation model usage will be charged and how it will be charged."
+                            },
+                            {
+                                "language": "de",
+                                "text": "Ob und wie eine Nutzung des Simulationsmodells abgerechnet wird."
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "LicenseModel"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "licenseModel",
+            "modelType": "ConceptDescription",
+            "id": "https://admin-shell.io/idta/SimulationModels/LicenseModel/1/0"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "tbd"
+                            },
+                            {
+                                "language": "de",
+                                "text": "tbd"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "Provide access to  simulation support service provided by the distributor via mail or phone"
+                            },
+                            {
+                                "language": "de",
+                                "text": "Zugang zum Simulationssupport des Inverkehrbringers via Mail oder Telefon."
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "simModManufacturerInformation",
+            "modelType": "ConceptDescription",
+            "id": "https://admin-shell.io/idta/SimulationModels/SimModManufacturerInformation/1/0"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "tbd"
+                            },
+                            {
+                                "language": "de",
+                                "text": "tbd"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "Predefined simulation period in seconds "
+                            },
+                            {
+                                "language": "de",
+                                "text": "Voreingestellter Simulationszeitraum in Sekunden "
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "DefaultSimTime"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "defaultSimTime",
+            "modelType": "ConceptDescription",
+            "id": "https://admin-shell.io/idta/SimulationModels/DefaultSimTime/1/0"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "tbd"
+                            },
+                            {
+                                "language": "de",
+                                "text": "tbd"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "name of the company"
+                            },
+                            {
+                                "language": "de",
+                                "text": "Name des Unternehmens"
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "Company"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "company",
+            "modelType": "ConceptDescription",
+            "id": "0173-1#02-AAW001#001"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "language"
+                            },
+                            {
+                                "language": "de",
+                                "text": "language"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "available language"
+                            },
+                            {
+                                "language": "de",
+                                "text": "verf\u00fcgbare Sprache"
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "language"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "language",
+            "modelType": "ConceptDescription",
+            "id": "0173-1#02-AAO895#003"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "tbd"
+                            },
+                            {
+                                "language": "de",
+                                "text": "tbd"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "electronic mail address of a business partner"
+                            },
+                            {
+                                "language": "de",
+                                "text": "elektronische Postadresse eines Gesch\u00e4ftspartners"
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "EmailAddress"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "emailAddress",
+            "modelType": "ConceptDescription",
+            "id": "0173-1#02-AAO198#002"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "tbd"
+                            },
+                            {
+                                "language": "de",
+                                "text": "tbd"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "public part of an unsymmetrical key pair to sign or encrypt text or messages"
+                            },
+                            {
+                                "language": "de",
+                                "text": "\u00f6ffentlicher Teil eines unsymmetrischen Schl\u00fcsselpaares zum Signieren oder Verschl\u00fcsseln von Text oder Nachrichten"
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "PublicKey"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "publicKey",
+            "modelType": "ConceptDescription",
+            "id": "0173-1#02-AAO200#002"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "tbd"
+                            },
+                            {
+                                "language": "de",
+                                "text": "tbd"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "characterization of an e-mail address according to its location or usage"
+                            },
+                            {
+                                "language": "de",
+                                "text": "Charakterisierung einer E-Mail-Adresse nach ihrem Standort oder ihrer Verwendung"
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "TypeOfEmailAddress"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "typeOfEmailAddress",
+            "modelType": "ConceptDescription",
+            "id": "0173-1#02-AAO199#003"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "tbd"
+                            },
+                            {
+                                "language": "de",
+                                "text": "tbd"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "characterization of a public key according to its encryption process"
+                            },
+                            {
+                                "language": "de",
+                                "text": "Charakterisierung eines \u00f6ffentlichen Schl\u00fcssels nach seinem Verschl\u00fcsselungsverfahren"
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "TypeOfPublicKey"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "typeOfPublicKey",
+            "modelType": "ConceptDescription",
+            "id": "0173-1#02-AAO201#002"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "tbd"
+                            },
+                            {
+                                "language": "de",
+                                "text": "tbd"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "Phone number including type"
+                            },
+                            {
+                                "language": "de",
+                                "text": "Rufnummer einschlie\u00dflich Typ"
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "Phone"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "phone",
+            "modelType": "ConceptDescription",
+            "id": "https://admin-shell.io/zvei/nameplate/1/0/ContactInformations/ContactInformation/Phone"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "tbd"
+                            },
+                            {
+                                "language": "de",
+                                "text": "tbd"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "characterization of a telephone according to its location or usage"
+                            },
+                            {
+                                "language": "de",
+                                "text": "Charakterisierung eines Telefons nach seinem Standort oder seiner Nutzung"
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "TypeOfTelephone"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "typeOfTelephone",
+            "modelType": "ConceptDescription",
+            "id": "0173-1#02-AAO137#003"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "tbd"
+                            },
+                            {
+                                "language": "de",
+                                "text": "tbd"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "Specification of the available time window"
+                            },
+                            {
+                                "language": "de",
+                                "text": "Spezifikation des verf\u00fcgbaren Zeitfensters"
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "AvailableTime"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "availableTime",
+            "modelType": "ConceptDescription",
+            "id": "https://admin-shell.io/zvei/nameplate/1/0/ContactInformations/ContactInformation/AvailableTime/"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "tbd"
+                            },
+                            {
+                                "language": "de",
+                                "text": "tbd"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "Useful settings of the simulation environment. Includes e.g. solver settings. "
+                            },
+                            {
+                                "language": "de",
+                                "text": "Sinnvolle Einstellungen der Simulationsumgebung. Beinhaltet z.B. Solvereinstellungen. "
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "solverAndTolerances",
+            "modelType": "ConceptDescription",
+            "id": "https://admin-shell.io/idta/SimulationModels/SolverAndTolerances/1/0"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "tbd"
+                            },
+                            {
+                                "language": "de",
+                                "text": "tbd"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "Solver with step size control recommended."
+                            },
+                            {
+                                "language": "de",
+                                "text": "Es wird eine Schrittweitensteuerung empfohlen."
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "stepSizeControlNeeded",
+            "modelType": "ConceptDescription",
+            "id": "https://admin-shell.io/idta/SimulationModels/StepSizeControlNeeded/1/0"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "tbd"
+                            },
+                            {
+                                "language": "de",
+                                "text": "tbd"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "Fixed integration step size, if there is no adaptive step size "
+                            },
+                            {
+                                "language": "de",
+                                "text": "Feste Integrationsschrittweite, wenn keine Schritttweitensteuerung"
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "FixedStepSize"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "fixedStepSize",
+            "modelType": "ConceptDescription",
+            "id": "https://admin-shell.io/idta/SimulationModels/FixedStepSize/1/0"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "tbd"
+                            },
+                            {
+                                "language": "de",
+                                "text": "tbd"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "(relative) tolerance for theadaptive step size "
+                            },
+                            {
+                                "language": "de",
+                                "text": "(relative) Toleranz f\u00fcr die Schrittweitensteuerung"
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "Tolerance"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "tolerance",
+            "modelType": "ConceptDescription",
+            "id": "https://admin-shell.io/idta/SimulationModels/Tolerance/1/0"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "tbd"
+                            },
+                            {
+                                "language": "de",
+                                "text": "tbd"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "Solver is integrated in the model (e.g. FMU for co-simulation)"
+                            },
+                            {
+                                "language": "de",
+                                "text": "Solver ist im Modell enthalten (z.B. FMU f\u00fcr Co-Simulation)"
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "SolverIncluded"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "solverIncluded",
+            "modelType": "ConceptDescription",
+            "id": "https://admin-shell.io/idta/SimulationModels/SolverIncluded/1/0"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "tbd"
+                            },
+                            {
+                                "language": "de",
+                                "text": "tbd"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "Stiff solver needed."
+                            },
+                            {
+                                "language": "de",
+                                "text": "Steifer Integrator erforderlich."
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "StiffSolverNeeded"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "stiffSolverNeeded",
+            "modelType": "ConceptDescription",
+            "id": "https://admin-shell.io/idta/SimulationModels/StiffSolverNeeded/1/0"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "tbd"
+                            },
+                            {
+                                "language": "de",
+                                "text": "tbd"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "List of validated tool-solver combinations"
+                            },
+                            {
+                                "language": "de",
+                                "text": "Liste der getestete Tool-Solver Kombinationen"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "testedToolSolverAlgorithm",
+            "modelType": "ConceptDescription",
+            "id": "https://admin-shell.io/idta/SimulationModels/TestedToolSolverAlgorithm/1/0"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "tbd"
+                            },
+                            {
+                                "language": "de",
+                                "text": "tbd"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "validated solver"
+                            },
+                            {
+                                "language": "de",
+                                "text": "Getesteter Solver"
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "SolverAlgorithm"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "solverAlgorithm",
+            "modelType": "ConceptDescription",
+            "id": "https://admin-shell.io/idta/SimulationModels/SolverAlgorithm/1/0"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "tbd"
+                            },
+                            {
+                                "language": "de",
+                                "text": "tbd"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "Further tool- and solver-specific information"
+                            },
+                            {
+                                "language": "de",
+                                "text": "weitere Tool- und Solver-spezifischen Angaben"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "toolSolverFurtherDescription",
+            "modelType": "ConceptDescription",
+            "id": "https://admin-shell.io/idta/SimulationModels/ToolSolverFurtherDescription/1/0"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "tbd"
+                            },
+                            {
+                                "language": "de",
+                                "text": "tbd"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "\"Designation of the exchange format of the model. E.G.: FMI 1.0, Co-Simulation, Platform / Source - Code. FMI 2.0.2, Model Exchange, Source - Code, S-function, Version 2, 64bit, mex - Format / or C-Code, Modelica 3, encoded, VHDL"
+                            },
+                            {
+                                "language": "de",
+                                "text": "Bezeichnung des Austauschformates des Modells. Z.B.: FMI 1.0, Co-Simulation, Plattform / Source - Code FMI 2.0.2, Model Exchange, Source - Code, S-function, Version 2, 64bit, mex - Format / bzw. C-Code Modelica 3, verschl\u00fcsselt, VHDL"
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "ModelFileType"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "modelFileType",
+            "modelType": "ConceptDescription",
+            "id": "https://admin-shell.io/idta/SimulationModels/ModelFileType/1/0"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "tbd"
+                            },
+                            {
+                                "language": "de",
+                                "text": "tbd"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "List of engineering disciplines supported or mapped with the model. "
+                            },
+                            {
+                                "language": "de",
+                                "text": "Liste der technischen Fachgebiete die mit dem Modell unterst\u00fctzt oder abbildet. "
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "EngineeringDomain"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "engineeringDomain",
+            "modelType": "ConceptDescription",
+            "id": "https://admin-shell.io/idta/SimulationModels/EngineeringDomain/1/0"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "List of supportet und not supported simlulation purposes"
+                            },
+                            {
+                                "language": "de",
+                                "text": "Liste unterst\u00fctzter und nicht unterst\u00fctzter Simulationsziele"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "This characteristic describes the simulation purpose or suitability for different simulation goals."
+                            },
+                            {
+                                "language": "de",
+                                "text": "Dieses Merkmal beschreibt den Simulationszweck oder die Eignung f\u00fcr verschiedene Simulationsziele."
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "SimPurpose"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "simPurpose",
+            "modelType": "ConceptDescription",
+            "id": "https://admin-shell.io/idta/SimulationModels/SimPurpose/1/0"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "Supported simulation purposes"
+                            },
+                            {
+                                "language": "de",
+                                "text": "Unterst\u00fctzte Simulationsziele"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "List of simulation purposes for which the model is intended."
+                            },
+                            {
+                                "language": "de",
+                                "text": "Liste der vom Simulationszwecke f\u00fcr die das Modell konzipiert ist."
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "PosSimPurpose"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "posSimPurpose",
+            "modelType": "ConceptDescription",
+            "id": "https://admin-shell.io/idta/SimulationModels/PosSimPurpose/1/0"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "Not supported simulation purposes"
+                            },
+                            {
+                                "language": "de",
+                                "text": "Ausgeschlossene Simulationsziele"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "List of simulation purposes for which the model is explicitly not suitable. "
+                            },
+                            {
+                                "language": "de",
+                                "text": "Liste der Simulationszwecke f\u00fcr die das Modell explizit nicht geeignet ist. "
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "NegSimPurpose"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "negSimPurpose",
+            "modelType": "ConceptDescription",
+            "id": "https://admin-shell.io/idta/SimulationModels/NegSimPurpose/1/0"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "tbd"
+                            },
+                            {
+                                "language": "de",
+                                "text": "tbd"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "List of basic physical characteristics which are represented by the model."
+                            },
+                            {
+                                "language": "de",
+                                "text": "Liste an grunds\u00e4tzlichen pysikalischen Eigenschaften welche durch das Modell abgebildet werden."
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "ScopeOfModel"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "scopeOfModel",
+            "modelType": "ConceptDescription",
+            "id": "https://admin-shell.io/idta/SimulationModels/ScopeOfModel/1/0"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "tbd"
+                            },
+                            {
+                                "language": "de",
+                                "text": "tbd"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "List of modeling approaches used for the model."
+                            },
+                            {
+                                "language": "de",
+                                "text": "Liste der Modellierungsans\u00e4tze die f\u00fcr das Modell genutzt wurden."
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "TypeOfModel"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "typeOfModel",
+            "modelType": "ConceptDescription",
+            "id": "https://admin-shell.io/idta/SimulationModels/TypeOfModel/1/0"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "tbd"
+                            },
+                            {
+                                "language": "de",
+                                "text": "tbd"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "Information about prerequisite environments or dependencies of underlying components on the target system."
+                            },
+                            {
+                                "language": "de",
+                                "text": "Informationen zu vorausgesetzten Umgebungen oder Abh\u00e4ngigkeiten umgebener Komponenten auf dem Zielsystem."
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "Environment"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "environment",
+            "modelType": "ConceptDescription",
+            "id": "https://admin-shell.io/idta/SimulationModels/Environment/1/0"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "tbd"
+                            },
+                            {
+                                "language": "de",
+                                "text": "tbd"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "Name of the operating system including version and architecture (e.g. Windows 10 64bit)"
+                            },
+                            {
+                                "language": "de",
+                                "text": "Name des Betriebssystems inklusive Version und Architektur (z.B. Windows 10 64bit)"
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "OperatingSystem"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "operatingSystem",
+            "modelType": "ConceptDescription",
+            "id": "https://admin-shell.io/idta/SimulationModels/OperatingSystem/1/0"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "tbd"
+                            },
+                            {
+                                "language": "de",
+                                "text": "tbd"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "List with required simulation tools, interpreters, model libraries or runtime libraries. In each case the exact designation of the software producer is given as free text."
+                            },
+                            {
+                                "language": "de",
+                                "text": "Liste mit vorrausgesetzten Simulationswerkzeugen, Interpreter, Modell-Bibliotheken oder Runtimebibliotheken. Es ist jeweils die genaue Bezeichung des Herstellers als Freitext angegeben."
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "ToolEnvironment"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "toolEnvironment",
+            "modelType": "ConceptDescription",
+            "id": "https://admin-shell.io/idta/SimulationModels/ToolEnvironment/1/0"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "tbd"
+                            },
+                            {
+                                "language": "de",
+                                "text": "tbd"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "Ability to use a visualization. This can be integrated in a model or the model offers capabilities for connection. The connection can be described in more detail under Ports."
+                            },
+                            {
+                                "language": "de",
+                                "text": "\"M\u00f6glichkeit der Nutzung einer Visualisierung. Diese kann in einem Modell integriert sein oder das Modell bietet M\u00f6glichkeiten zur Anbindung. Die Anbindung kann unter Ports genauer beschrieben sein."
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "visualizationInformation",
+            "modelType": "ConceptDescription",
+            "id": "https://admin-shell.io/idta/SimulationModels/VisualizationInformation/1/0"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "tbd"
+                            },
+                            {
+                                "language": "de",
+                                "text": "tbd"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "Interfaces of the model. This includes inputs, outputs as well as acausal connections (e.g. mechanical connections). In addition, it is specified here whether the model provides binary interfaces (e.g. for visualization)."
+                            },
+                            {
+                                "language": "de",
+                                "text": "Schnittstellen des Modells. Dies beinhaltet sowohl Eing\u00e4nge, Ausg\u00e4nge als auch akausale Verbindungen (z.B. mechanische Verbindungen). Zudem wird hier angegeben, ob das Modell bin\u00e4re Schnittstellen beinhaltet (z.B. f\u00fcr die Visualisierung)."
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "Ports"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "ports",
+            "modelType": "ConceptDescription",
+            "id": "https://admin-shell.io/idta/SimulationModels/Ports/1/0"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "tbd"
+                            },
+                            {
+                                "language": "de",
+                                "text": "tbd"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "List of ports of the model. These include a name, a description, a list of variables, and a list of ports."
+                            },
+                            {
+                                "language": "de",
+                                "text": "Liste der Ports des Modells. Diese beinhalten einen Namen, eine Beschreibung, eine Liste an Variablen sowie eine Liste an Ports."
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "PortsConnector"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "portsConnector",
+            "modelType": "ConceptDescription",
+            "id": "https://admin-shell.io/idta/SimulationModels/PortsConnector/1/0"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "tbd"
+                            },
+                            {
+                                "language": "de",
+                                "text": "tbd"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "Name of the Connector Port."
+                            },
+                            {
+                                "language": "de",
+                                "text": "Name des Port-Connectors."
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "PortConnectorName"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "portConName",
+            "modelType": "ConceptDescription",
+            "id": "https://admin-shell.io/idta/SimulationModels/PortsConnectorName/1/0"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "tbd"
+                            },
+                            {
+                                "language": "de",
+                                "text": "tbd"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "List of variables of the port."
+                            },
+                            {
+                                "language": "de",
+                                "text": "Liste der Variablen des Ports."
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "Variable"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "variable",
+            "modelType": "ConceptDescription",
+            "id": "https://admin-shell.io/idta/SimulationModels/Variable/1/0"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "tbd"
+                            },
+                            {
+                                "language": "de",
+                                "text": "tbd"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "Name of the variable."
+                            },
+                            {
+                                "language": "de",
+                                "text": "Name der Variable."
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "VariableName"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "variableName",
+            "modelType": "ConceptDescription",
+            "id": "https://admin-shell.io/idta/SimulationModels/VariableName/1/0"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "tbd"
+                            },
+                            {
+                                "language": "de",
+                                "text": "tbd"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "Description of the variable."
+                            },
+                            {
+                                "language": "de",
+                                "text": "Beschreibung der Variable."
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "variableDescription",
+            "modelType": "ConceptDescription",
+            "id": "https://admin-shell.io/idta/SimulationModels/VariableDescription/1/0"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "tbd"
+                            },
+                            {
+                                "language": "de",
+                                "text": "tbd"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "Type of the variable (e.g. Real, Integer, Boolean, String or Enum)."
+                            },
+                            {
+                                "language": "de",
+                                "text": "Typ der Variable (z.B. Real, Integer, Boolean, String oder Enum)."
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "VariableType"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "type",
+            "modelType": "ConceptDescription",
+            "id": "https://admin-shell.io/idta/SimulationModels/VariableType/1/0"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "tbd"
+                            },
+                            {
+                                "language": "de",
+                                "text": "tbd"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "The causality of the variable: input to inputs, output to ouputs, acausal connections (e.g. mechanical connection) do not have causality."
+                            },
+                            {
+                                "language": "de",
+                                "text": "Kausalit\u00e4t der Variable: input f\u00fcr Eing\u00e4nge, output f\u00fcr Ausg\u00e4nge, akausale Verbindungen (z.B. mechanische Verbindung) besitzen keine Kausalit\u00e4t."
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "VariableCausality"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "variableCausality",
+            "modelType": "ConceptDescription",
+            "id": "https://admin-shell.io/idta/SimulationModels/VariableCausality/1/0"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "tbd"
+                            },
+                            {
+                                "language": "de",
+                                "text": "tbd"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "Prefix for acausal variable. Potential variables are set equal when connecting (no prefix). Stream variables are connected according to Kirchhoff's law, i.e. the sum of the variables equals zero. The bi-directional flow of matter is described with \"stream\" (e.g. for enthalpy)."
+                            },
+                            {
+                                "language": "de",
+                                "text": "Prefix f\u00fcr akausale Variable. Potentialvariablen werden beim Verbinden gleich gesetzt (kein Prefix). Flussvariablen werden nach Kirchhoffs Gesetz verbunden, d.h. die Summe der Variablen entspricht Null. Der bi-direktionale Fluss von Materie wird mit \"stream\" beschrieben (z.B. f\u00fcr Enthalpie)."
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "VariablePrefix"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "variablePrefix",
+            "modelType": "ConceptDescription",
+            "id": "https://admin-shell.io/idta/SimulationModels/VariablePrefix/1/0"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "tbd"
+                            },
+                            {
+                                "language": "de",
+                                "text": "tbd"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "The most common units can be selected here. .. If \"others\" is selected, a free text can be entered."
+                            },
+                            {
+                                "language": "de",
+                                "text": "Hier k\u00f6nnen die gebr\u00e4uchlichsten Einheiten ausgew\u00e4hlt werden. .. Bei Auswahl \"others\" kann ein Freitext angegeben werden."
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "UnitList"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "unitList",
+            "modelType": "ConceptDescription",
+            "id": "https://admin-shell.io/idta/SimulationModels/UnitList/1/0"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "tbd"
+                            },
+                            {
+                                "language": "de",
+                                "text": "tbd"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "Text field for missing units of the list"
+                            },
+                            {
+                                "language": "de",
+                                "text": "Freitext f\u00fcr fehlende Einheiten der Liste"
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "UnitDescription"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "unitDescription",
+            "modelType": "ConceptDescription",
+            "id": "https://admin-shell.io/idta/SimulationModels/UnitDescription/1/0"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "tbd"
+                            },
+                            {
+                                "language": "de",
+                                "text": "tbd"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "Range of values for the variable (e.g. [min, max], [min, max[, ]min, max], ]min, max[, {val1, val2, ...})."
+                            },
+                            {
+                                "language": "de",
+                                "text": "Wertebereich f\u00fcr die Variable (z.B. [min, max], [min, max[, ]min, max], ]min, max[, {val1, val2, ...})."
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "Range"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "range",
+            "modelType": "ConceptDescription",
+            "id": "https://admin-shell.io/idta/SimulationModels/Range/1/0"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "tbd"
+                            },
+                            {
+                                "language": "de",
+                                "text": "tbd"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "Binary interfaces (binaryType) based on the FMI 3.0 standard (https://fmi-standard.org/docs/3.0-dev/#definition-of-types). At this point the name (e.g. \"Binary interface visualization\") and the description (e.g. \"Interface for binary transfer of visualization information\") are specified."
+                            },
+                            {
+                                "language": "de",
+                                "text": "Bin\u00e4re Schnittstellen (binaryType) basierend auf dem FMI-3.0-Standard (https://fmi-standard.org/docs/3.0-dev/#definition-of-types). An dieser Stelle werden der Name (z.B. \"Bin\u00e4rschnittstelle Visualisierung\") und die Beschreibung (z.B. \"Schnittstelle zum bin\u00e4ren \u00dcbertragen von Visualisierungsinformationen\") angegeben."
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "BinaryConnector"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "binaryConnector",
+            "modelType": "ConceptDescription",
+            "id": "https://admin-shell.io/idta/SimulationModels/BinaryConnector/1/0"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "tbd"
+                            },
+                            {
+                                "language": "de",
+                                "text": "tbd"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "Binary interface name."
+                            },
+                            {
+                                "language": "de",
+                                "text": "Name der bin\u00e4ren Schnittstelle."
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "BinaryConName"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "binConName",
+            "modelType": "ConceptDescription",
+            "id": "https://admin-shell.io/idta/SimulationModels/BinaryConnectorName/1/0"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "tbd"
+                            },
+                            {
+                                "language": "de",
+                                "text": "tbd"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "Binary interface description."
+                            },
+                            {
+                                "language": "de",
+                                "text": "Beschreibung der bin\u00e4ren Schnittstelle."
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "binaryConDescription",
+            "modelType": "ConceptDescription",
+            "id": "https://admin-shell.io/idta/SimulationModels/BinaryConDescription/1/0"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "tbd"
+                            },
+                            {
+                                "language": "de",
+                                "text": "tbd"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "release notes link or file"
+                            },
+                            {
+                                "language": "de",
+                                "text": "Datei oder Verkn\u00fcpfung zum Release Notes Dokument"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "modelFileReleaseNotesFile",
+            "modelType": "ConceptDescription",
+            "id": "https://admin-shell.io/idta/SimulationModels/ModelFileReleaseNotesFile/1/0"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "tbd"
+                            },
+                            {
+                                "language": "de",
+                                "text": "tbd"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "Description of dependencies to associated hardware and software. "
+                            },
+                            {
+                                "language": "de",
+                                "text": "Beschreibung von Abh\u00e4ngigkeiten zu umgebener Hardware und Software. "
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "dependencyEnvironment",
+            "modelType": "ConceptDescription",
+            "id": "https://admin-shell.io/idta/SimulationModels/DependencyEnvironment/1/0"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "tbd"
+                            },
+                            {
+                                "language": "de",
+                                "text": "tbd"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "Properties of the model with regarding to concrete simulation tools"
+                            },
+                            {
+                                "language": "de",
+                                "text": "Eigenschaften des Modells bez\u00fcglich konkreter Simulationswerkzeuge."
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "SimulationTool"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "simulationTool",
+            "modelType": "ConceptDescription",
+            "id": "https://admin-shell.io/idta/SimulationModels/SimulationTool/1/0"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "simToolName"
+                            },
+                            {
+                                "language": "de",
+                                "text": "simToolName"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "Name of the simulation tool including version."
+                            },
+                            {
+                                "language": "de",
+                                "text": "Name des Simulationtools inklusive Version"
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "simToolName"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "simToolName",
+            "modelType": "ConceptDescription",
+            "id": "https://admin-shell.io/idta/SimulationModels/SimToolName/1/0"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "tbd"
+                            },
+                            {
+                                "language": "de",
+                                "text": "tbd"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "Dependencies of Simulation Tools"
+                            },
+                            {
+                                "language": "de",
+                                "text": "Abh\u00e4ngigkeiten des Simulationtools"
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "DependencySimTool"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "dependencySimTool",
+            "modelType": "ConceptDescription",
+            "id": "https://admin-shell.io/idta/SimulationModels/DependencySimTool/1/0"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "tbd"
+                            },
+                            {
+                                "language": "de",
+                                "text": "tbd"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "Name of necessary compiler including version"
+                            },
+                            {
+                                "language": "de",
+                                "text": "Name des ben\u00f6tigten Comilers inklusive Version"
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "Compiler"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "compiler",
+            "modelType": "ConceptDescription",
+            "id": "https://admin-shell.io/idta/SimulationModels/Compiler/1/0"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "de",
+                                "text": "Herstellername"
+                            },
+                            {
+                                "language": "en",
+                                "text": "Manufacturer name"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "de",
+                                "text": "Bezeichnung f\u00fcr eine nat\u00fcrliche oder juristische Person, die f\u00fcr die Auslegung, Herstellung und Verpackung sowie die Etikettierung eines Produkts im Hinblick auf das 'Inverkehrbringen' im eigenen Namen verantwortlich ist"
+                            },
+                            {
+                                "language": "en",
+                                "text": "legally valid designation of the natural or judicial person which is directly responsible for the design, production, packaging and labeling of a product in respect to its being brought into circulation"
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "ManNam"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "TO_FIX",
+            "modelType": "ConceptDescription",
+            "id": "0173-1#02-AAO677#002",
+            "isCaseOf": [
+                {
+                    "type": "ExternalReference",
+                    "keys": [
+                        {
+                            "type": "GlobalReference",
+                            "value": "0173-1#02-AAO677#002"
+                        }
+                    ]
+                }
             ]
-          },
-          "qualifiers": [
-            {
-              "kind": "ConceptQualifier",
-              "type": "FormTitle",
-              "valueType": "xs:string",
-              "value": "SimulationModel"
-            },
-            {
-              "kind": "ConceptQualifier",
-              "type": "FormInfo",
-              "valueType": "xs:string",
-              "value": "Merkmalssammlung zur Bereitstellung oder Anfrage von Simulationsmodellen. Die Modelle k\u00F6nnen von der Zielstellung und inhaltlich beschrieben werden."
-            },
-            {
-              "kind": "ConceptQualifier",
-              "type": "PresetIdShort",
-              "valueType": "xs:string",
-              "value": "To be filleSimulationModel\u0027{0:00}\u0027"
-            },
-            {
-              "kind": "ConceptQualifier",
-              "type": "Multiplicity",
-              "valueType": "xs:string",
-              "value": "ZeroToMany"
-            }
-          ],
-          "value": [
-            {
-              "category": "CONSTANT",
-              "idShort": "Summary",
-              "semanticId": {
-                "type": "ExternalReference",
-                "keys": [
-                  {
-                    "type": "GlobalReference",
-                    "value": "https://admin-shell.io/idta/SimulationModels/Summary/1/0"
-                  }
-                ]
-              },
-              "qualifiers": [
+        },
+        {
+            "embeddedDataSpecifications": [
                 {
-                  "kind": "ConceptQualifier",
-                  "type": "FormTitle",
-                  "valueType": "xs:string",
-                  "value": "summary"
-                },
-                {
-                  "kind": "ConceptQualifier",
-                  "type": "FormInfo",
-                  "valueType": "xs:string",
-                  "value": "Summary of the contents of the simulation model in text form. "
-                },
-                {
-                  "kind": "ConceptQualifier",
-                  "type": "PresetIdShort",
-                  "valueType": "xs:string",
-                  "value": "summary"
-                },
-                {
-                  "kind": "ConceptQualifier",
-                  "type": "Multiplicity",
-                  "valueType": "xs:string",
-                  "value": "ZeroToOne"
-                }
-              ],
-              "modelType": "MultiLanguageProperty"
-            },
-            {
-              "idShort": "SimPurpose",
-              "semanticId": {
-                "type": "ExternalReference",
-                "keys": [
-                  {
-                    "type": "GlobalReference",
-                    "value": "https://admin-shell.io/idta/SimulationModels/SimPurpose/1/0"
-                  }
-                ]
-              },
-              "qualifiers": [
-                {
-                  "kind": "ConceptQualifier",
-                  "type": "FormTitle",
-                  "valueType": "xs:string",
-                  "value": "simPurpose"
-                },
-                {
-                  "kind": "ConceptQualifier",
-                  "type": "FormInfo",
-                  "valueType": "xs:string",
-                  "value": "This characteristic describes the simulation purpose or suitability for different simulation goals."
-                },
-                {
-                  "kind": "ConceptQualifier",
-                  "type": "PresetIdShort",
-                  "valueType": "xs:string",
-                  "value": "simPurpose"
-                },
-                {
-                  "kind": "ConceptQualifier",
-                  "type": "Multiplicity",
-                  "valueType": "xs:string",
-                  "value": "One"
-                }
-              ],
-              "value": [
-                {
-                  "idShort": "PosSimPurpose",
-                  "semanticId": {
-                    "type": "ExternalReference",
-                    "keys": [
-                      {
-                        "type": "GlobalReference",
-                        "value": "https://admin-shell.io/idta/SimulationModels/PosSimPurpose/1/0"
-                      }
-                    ]
-                  },
-                  "qualifiers": [
-                    {
-                      "kind": "ConceptQualifier",
-                      "type": "FormTitle",
-                      "valueType": "xs:string",
-                      "value": "posSimPurpose"
-                    },
-                    {
-                      "kind": "ConceptQualifier",
-                      "type": "FormInfo",
-                      "valueType": "xs:string",
-                      "value": "List of simulation purposes for which the model is intended."
-                    },
-                    {
-                      "kind": "ConceptQualifier",
-                      "type": "PresetIdShort",
-                      "valueType": "xs:string",
-                      "value": "posSimPurpose\u0027{0:00}\u0027"
-                    },
-                    {
-                      "kind": "ConceptQualifier",
-                      "type": "Multiplicity",
-                      "valueType": "xs:string",
-                      "value": "OneToMany"
-                    },
-                    {
-                      "kind": "ConceptQualifier",
-                      "type": "FormChoices",
-                      "valueType": "xs:string",
-                      "value": "Concept evaluation; Sizing; Energy consumption; Control design; Behaviour in fault condition; Validation and testing; Virtual commissioning; Condition monitoring; Predictive maintenance; Operator Training; Teaching"
-                    }
-                  ],
-                  "valueType": "xs:string",
-                  "modelType": "Property"
-                },
-                {
-                  "idShort": "NegSimPurpose",
-                  "semanticId": {
-                    "type": "ExternalReference",
-                    "keys": [
-                      {
-                        "type": "GlobalReference",
-                        "value": "https://admin-shell.io/idta/SimulationModels/NegSimPurpose/1/0"
-                      }
-                    ]
-                  },
-                  "qualifiers": [
-                    {
-                      "kind": "ConceptQualifier",
-                      "type": "FormTitle",
-                      "valueType": "xs:string",
-                      "value": "negSimPurpose"
-                    },
-                    {
-                      "kind": "ConceptQualifier",
-                      "type": "FormInfo",
-                      "valueType": "xs:string",
-                      "value": "List of simulation purposes for which the model is explicitly not suitable. "
-                    },
-                    {
-                      "kind": "ConceptQualifier",
-                      "type": "PresetIdShort",
-                      "valueType": "xs:string",
-                      "value": "negSimPurpose\u0027{0:00}\u0027"
-                    },
-                    {
-                      "kind": "ConceptQualifier",
-                      "type": "Multiplicity",
-                      "valueType": "xs:string",
-                      "value": "ZeroToMany"
-                    },
-                    {
-                      "kind": "ConceptQualifier",
-                      "type": "FormChoices",
-                      "valueType": "xs:string",
-                      "value": "Concept evaluation; Sizing; Energy consumption; Control design; Behaviour in fault condition; Validation and testing; Virtual commissioning; Condition monitoring; Predictive maintenance; Operator Training; Teaching"
-                    }
-                  ],
-                  "valueType": "xs:string",
-                  "modelType": "Property"
-                }
-              ],
-              "modelType": "SubmodelElementCollection"
-            },
-            {
-              "idShort": "TypeOfModel",
-              "semanticId": {
-                "type": "ExternalReference",
-                "keys": [
-                  {
-                    "type": "GlobalReference",
-                    "value": "https://admin-shell.io/idta/SimulationModels/TypeOfModel/1/0"
-                  }
-                ]
-              },
-              "qualifiers": [
-                {
-                  "kind": "ConceptQualifier",
-                  "type": "FormTitle",
-                  "valueType": "xs:string",
-                  "value": "typeOfModel"
-                },
-                {
-                  "kind": "ConceptQualifier",
-                  "type": "FormInfo",
-                  "valueType": "xs:string",
-                  "value": "List of modeling approaches used for the model."
-                },
-                {
-                  "kind": "ConceptQualifier",
-                  "type": "PresetIdShort",
-                  "valueType": "xs:string",
-                  "value": "typeOfModelDesc"
-                },
-                {
-                  "kind": "ConceptQualifier",
-                  "type": "Multiplicity",
-                  "valueType": "xs:string",
-                  "value": "ZeroToMany"
-                },
-                {
-                  "kind": "ConceptQualifier",
-                  "type": "FormChoices",
-                  "valueType": "xs:string",
-                  "value": "Linear model; Nonlinear model; Data-driven model; Lumped element model; Fixed causality model; Acausal model "
-                }
-              ],
-              "valueType": "xs:string",
-              "modelType": "Property"
-            },
-            {
-              "idShort": "ScopeOfModel",
-              "semanticId": {
-                "type": "ExternalReference",
-                "keys": [
-                  {
-                    "type": "GlobalReference",
-                    "value": "https://admin-shell.io/idta/SimulationModels/ScopeOfModel/1/0"
-                  }
-                ]
-              },
-              "qualifiers": [
-                {
-                  "kind": "ConceptQualifier",
-                  "type": "FormTitle",
-                  "valueType": "xs:string",
-                  "value": "scopeOfModel"
-                },
-                {
-                  "kind": "ConceptQualifier",
-                  "type": "FormInfo",
-                  "valueType": "xs:string",
-                  "value": "List of basic physical characteristics which are represented by the model."
-                },
-                {
-                  "kind": "ConceptQualifier",
-                  "type": "PresetIdShort",
-                  "valueType": "xs:string",
-                  "value": "scopeOfModel"
-                },
-                {
-                  "kind": "ConceptQualifier",
-                  "type": "Multiplicity",
-                  "valueType": "xs:string",
-                  "value": "OneToMany"
-                },
-                {
-                  "kind": "ConceptQualifier",
-                  "type": "FormChoices",
-                  "valueType": "xs:string",
-                  "value": "Logic and timing behaviour; Geometry; Kinematics; Dynamics; Distribution networks; Network communication; Visualization"
-                }
-              ],
-              "valueType": "xs:string",
-              "modelType": "Property"
-            },
-            {
-              "idShort": "LicenseModel",
-              "semanticId": {
-                "type": "ExternalReference",
-                "keys": [
-                  {
-                    "type": "GlobalReference",
-                    "value": "https://admin-shell.io/idta/SimulationModels/LicenseModel/1/0"
-                  }
-                ]
-              },
-              "qualifiers": [
-                {
-                  "kind": "ConceptQualifier",
-                  "type": "FormTitle",
-                  "valueType": "xs:string",
-                  "value": "licenseModel"
-                },
-                {
-                  "kind": "ConceptQualifier",
-                  "type": "FormInfo",
-                  "valueType": "xs:string",
-                  "value": "If a simulation model usage will be charged and how it will be charged."
-                },
-                {
-                  "kind": "ConceptQualifier",
-                  "type": "PresetIdShort",
-                  "valueType": "xs:string",
-                  "value": "licenseModel"
-                },
-                {
-                  "kind": "ConceptQualifier",
-                  "type": "Multiplicity",
-                  "valueType": "xs:string",
-                  "value": "ZeroToOne"
-                },
-                {
-                  "kind": "ConceptQualifier",
-                  "type": "FormChoices",
-                  "valueType": "xs:string",
-                  "value": "free; perpetual; subscription; volume-based"
-                }
-              ],
-              "valueType": "xs:string",
-              "modelType": "Property"
-            },
-            {
-              "idShort": "EngineeringDomain",
-              "semanticId": {
-                "type": "ExternalReference",
-                "keys": [
-                  {
-                    "type": "GlobalReference",
-                    "value": "https://admin-shell.io/idta/SimulationModels/EngineeringDomain/1/0"
-                  }
-                ]
-              },
-              "qualifiers": [
-                {
-                  "kind": "ConceptQualifier",
-                  "type": "FormTitle",
-                  "valueType": "xs:string",
-                  "value": "engineeringDomainList"
-                },
-                {
-                  "kind": "ConceptQualifier",
-                  "type": "FormInfo",
-                  "valueType": "xs:string",
-                  "value": "List of engineering disciplines supported or mapped with the model. "
-                },
-                {
-                  "kind": "ConceptQualifier",
-                  "type": "PresetIdShort",
-                  "valueType": "xs:string",
-                  "value": "engineeringDomainList\u0027{0:00}\u0027"
-                },
-                {
-                  "kind": "ConceptQualifier",
-                  "type": "Multiplicity",
-                  "valueType": "xs:string",
-                  "value": "ZeroToMany"
-                },
-                {
-                  "kind": "ConceptQualifier",
-                  "type": "FormChoices",
-                  "valueType": "xs:string",
-                  "value": "Hydraulic Engineering; Electrical Engineering; Pneumatic Engineering; Mechanical Engineering; Material Flow; Robotics; Image Processing; Data Engineering; Process Engineering; Workflow Engineering; HMI Engineering; Control Engineering"
-                }
-              ],
-              "valueType": "xs:string",
-              "modelType": "Property"
-            },
-            {
-              "idShort": "Environment",
-              "semanticId": {
-                "type": "ExternalReference",
-                "keys": [
-                  {
-                    "type": "GlobalReference",
-                    "value": "https://admin-shell.io/idta/SimulationModels/Environment/1/0"
-                  }
-                ]
-              },
-              "qualifiers": [
-                {
-                  "kind": "ConceptQualifier",
-                  "type": "FormTitle",
-                  "valueType": "xs:string",
-                  "value": "environment"
-                },
-                {
-                  "kind": "ConceptQualifier",
-                  "type": "FormInfo",
-                  "valueType": "xs:string",
-                  "value": "Information about prerequisite environments or dependencies of underlying components on the target system."
-                },
-                {
-                  "kind": "ConceptQualifier",
-                  "type": "PresetIdShort",
-                  "valueType": "xs:string",
-                  "value": "environment"
-                },
-                {
-                  "kind": "ConceptQualifier",
-                  "type": "Multiplicity",
-                  "valueType": "xs:string",
-                  "value": "ZeroToMany"
-                }
-              ],
-              "value": [
-                {
-                  "idShort": "OperatingSystem",
-                  "semanticId": {
-                    "type": "ExternalReference",
-                    "keys": [
-                      {
-                        "type": "GlobalReference",
-                        "value": "https://admin-shell.io/idta/SimulationModels/OperatingSystem/1/0"
-                      }
-                    ]
-                  },
-                  "qualifiers": [
-                    {
-                      "kind": "ConceptQualifier",
-                      "type": "FormTitle",
-                      "valueType": "xs:string",
-                      "value": "operatingSystem"
-                    },
-                    {
-                      "kind": "ConceptQualifier",
-                      "type": "FormInfo",
-                      "valueType": "xs:string",
-                      "value": "Name of the operating system including version and architecture (e.g. Windows 10 64bit)"
-                    },
-                    {
-                      "kind": "ConceptQualifier",
-                      "type": "PresetIdShort",
-                      "valueType": "xs:string",
-                      "value": "operatingSystem\u0027{0:00}\u0027"
-                    },
-                    {
-                      "kind": "ConceptQualifier",
-                      "type": "Multiplicity",
-                      "valueType": "xs:string",
-                      "value": "One"
-                    }
-                  ],
-                  "valueType": "xs:string",
-                  "modelType": "Property"
-                },
-                {
-                  "idShort": "ToolEnvironment",
-                  "semanticId": {
-                    "type": "ExternalReference",
-                    "keys": [
-                      {
-                        "type": "GlobalReference",
-                        "value": "https://admin-shell.io/idta/SimulationModels/ToolEnvironment/1/0"
-                      }
-                    ]
-                  },
-                  "qualifiers": [
-                    {
-                      "kind": "ConceptQualifier",
-                      "type": "FormTitle",
-                      "valueType": "xs:string",
-                      "value": "toolEnvironment"
-                    },
-                    {
-                      "kind": "ConceptQualifier",
-                      "type": "FormInfo",
-                      "valueType": "xs:string",
-                      "value": "List with required simulation tools, interpreters, model libraries or runtime libraries. In each case the exact designation of the software producer is given as free text."
-                    },
-                    {
-                      "kind": "ConceptQualifier",
-                      "type": "PresetIdShort",
-                      "valueType": "xs:string",
-                      "value": "toolEnvironment\u0027{0:00}\u0027"
-                    },
-                    {
-                      "kind": "ConceptQualifier",
-                      "type": "Multiplicity",
-                      "valueType": "xs:string",
-                      "value": "ZeroToMany"
-                    }
-                  ],
-                  "valueType": "xs:string",
-                  "modelType": "Property"
-                },
-                {
-                  "category": "CONSTANT",
-                  "idShort": "DependencyEnvironment",
-                  "semanticId": {
-                    "type": "ExternalReference",
-                    "keys": [
-                      {
-                        "type": "GlobalReference",
-                        "value": "https://admin-shell.io/idta/SimulationModels/DependencyEnvironment/1/0"
-                      }
-                    ]
-                  },
-                  "qualifiers": [
-                    {
-                      "kind": "ConceptQualifier",
-                      "type": "FormTitle",
-                      "valueType": "xs:string",
-                      "value": "dependencyEnvironment"
-                    },
-                    {
-                      "kind": "ConceptQualifier",
-                      "type": "FormInfo",
-                      "valueType": "xs:string",
-                      "value": "Description of dependencies to associated hardware and software. "
-                    },
-                    {
-                      "kind": "ConceptQualifier",
-                      "type": "PresetIdShort",
-                      "valueType": "xs:string",
-                      "value": "dependencyEnvironment"
-                    },
-                    {
-                      "kind": "ConceptQualifier",
-                      "type": "Multiplicity",
-                      "valueType": "xs:string",
-                      "value": "ZeroToOne"
-                    }
-                  ],
-                  "modelType": "MultiLanguageProperty"
-                },
-                {
-                  "idShort": "VisualizationInformation",
-                  "semanticId": {
-                    "type": "ExternalReference",
-                    "keys": [
-                      {
-                        "type": "GlobalReference",
-                        "value": "https://admin-shell.io/idta/SimulationModels/VisualizationInformation/1/0"
-                      }
-                    ]
-                  },
-                  "qualifiers": [
-                    {
-                      "kind": "ConceptQualifier",
-                      "type": "FormTitle",
-                      "valueType": "xs:string",
-                      "value": "visualizationInformation"
-                    },
-                    {
-                      "kind": "ConceptQualifier",
-                      "type": "FormInfo",
-                      "valueType": "xs:string",
-                      "value": "Ability to use a visualization. This can be integrated in a model or the model offers capabilities for connection. The connection can be described in more detail under ports."
-                    },
-                    {
-                      "kind": "ConceptQualifier",
-                      "type": "PresetIdShort",
-                      "valueType": "xs:string",
-                      "value": "visualizationInformation"
-                    },
-                    {
-                      "kind": "ConceptQualifier",
-                      "type": "Multiplicity",
-                      "valueType": "xs:string",
-                      "value": "ZeroToOne"
-                    },
-                    {
-                      "kind": "ConceptQualifier",
-                      "type": "FormChoices",
-                      "valueType": "xs:string",
-                      "value": "separately; integrated; none"
-                    }
-                  ],
-                  "valueType": "xs:string",
-                  "modelType": "Property"
-                },
-                {
-                  "category": "CONSTANT",
-                  "idShort": "SimulationTool",
-                  "semanticId": {
-                    "type": "ExternalReference",
-                    "keys": [
-                      {
-                        "type": "GlobalReference",
-                        "value": "https://admin-shell.io/idta/SimulationModels/SimulationTool/1/0"
-                      }
-                    ]
-                  },
-                  "qualifiers": [
-                    {
-                      "kind": "ConceptQualifier",
-                      "type": "FormTitle",
-                      "valueType": "xs:string",
-                      "value": "simulationTool"
-                    },
-                    {
-                      "kind": "ConceptQualifier",
-                      "type": "FormInfo",
-                      "valueType": "xs:string",
-                      "value": "Eigenschaften des Modells bez\u00FCglich konkreter Simulationswerkzeuge."
-                    },
-                    {
-                      "kind": "ConceptQualifier",
-                      "type": "PresetIdShort",
-                      "valueType": "xs:string",
-                      "value": "simulationTool\u0027{0:00}\u0027"
-                    },
-                    {
-                      "kind": "ConceptQualifier",
-                      "type": "Multiplicity",
-                      "valueType": "xs:string",
-                      "value": "OneToMany"
-                    }
-                  ],
-                  "value": [
-                    {
-                      "category": "CONSTANT",
-                      "idShort": "SimToolName",
-                      "semanticId": {
+                    "dataSpecification": {
                         "type": "ExternalReference",
                         "keys": [
-                          {
-                            "type": "GlobalReference",
-                            "value": "https://admin-shell.io/idta/SimulationModel/SimToolName/1/0"
-                          }
-                        ]
-                      },
-                      "qualifiers": [
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "FormTitle",
-                          "valueType": "xs:string",
-                          "value": "simToolName"
-                        },
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "FormInfo",
-                          "valueType": "xs:string",
-                          "value": "Name of the simulation tool including version."
-                        },
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "PresetIdShort",
-                          "valueType": "xs:string",
-                          "value": "simToolName"
-                        },
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "Multiplicity",
-                          "valueType": "xs:string",
-                          "value": "One"
-                        }
-                      ],
-                      "valueType": "xs:string",
-                      "modelType": "Property"
-                    },
-                    {
-                      "category": "CONSTANT",
-                      "idShort": "DependencySimTool",
-                      "semanticId": {
-                        "type": "ExternalReference",
-                        "keys": [
-                          {
-                            "type": "GlobalReference",
-                            "value": "https://admin-shell.io/idta/SimulationModels/DependencySimTool/1/0"
-                          }
-                        ]
-                      },
-                      "qualifiers": [
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "FormTitle",
-                          "valueType": "xs:string",
-                          "value": "dependencySimTool"
-                        },
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "FormInfo",
-                          "valueType": "xs:string",
-                          "value": "Dependencies of Simulation Tools"
-                        },
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "PresetIdShort",
-                          "valueType": "xs:string",
-                          "value": "dependencySimTool\u0027{0:00}\u0027"
-                        },
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "Multiplicity",
-                          "valueType": "xs:string",
-                          "value": "ZeroToMany"
-                        }
-                      ],
-                      "valueType": "xs:string",
-                      "modelType": "Property"
-                    },
-                    {
-                      "category": "CONSTANT",
-                      "idShort": "Compiler",
-                      "semanticId": {
-                        "type": "ExternalReference",
-                        "keys": [
-                          {
-                            "type": "GlobalReference",
-                            "value": "https://admin-shell.io/idta/SimulationModels/Compiler/1/0"
-                          }
-                        ]
-                      },
-                      "qualifiers": [
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "FormTitle",
-                          "valueType": "xs:string",
-                          "value": "compiler"
-                        },
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "FormInfo",
-                          "valueType": "xs:string",
-                          "value": "Name of necessary compiler including version"
-                        },
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "PresetIdShort",
-                          "valueType": "xs:string",
-                          "value": "compiler\u0027{0:00}\u0027"
-                        },
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "Multiplicity",
-                          "valueType": "xs:string",
-                          "value": "ZeroToMany"
-                        }
-                      ],
-                      "valueType": "xs:string",
-                      "modelType": "Property"
-                    },
-                    {
-                      "idShort": "SolverAndTolerances",
-                      "semanticId": {
-                        "type": "ExternalReference",
-                        "keys": [
-                          {
-                            "type": "GlobalReference",
-                            "value": "https://admin-shell.io/idta/SimulationModels/SolverAndTolerances/1/0"
-                          }
-                        ]
-                      },
-                      "qualifiers": [
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "FormTitle",
-                          "valueType": "xs:string",
-                          "value": "solverAndTolerances"
-                        },
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "FormInfo",
-                          "valueType": "xs:string",
-                          "value": "Useful settings of the simulation environment. Includes e.g. solver settings. "
-                        },
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "PresetIdShort",
-                          "valueType": "xs:string",
-                          "value": "solverAndTolerances"
-                        },
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "Multiplicity",
-                          "valueType": "xs:string",
-                          "value": "One"
-                        }
-                      ],
-                      "value": [
-                        {
-                          "idShort": "StepSizeControlNeeded",
-                          "semanticId": {
-                            "type": "ExternalReference",
-                            "keys": [
-                              {
+                            {
                                 "type": "GlobalReference",
-                                "value": "https://admin-shell.io/idta/SimulationModels/StepSizeControlNeeded/1/0"
-                              }
-                            ]
-                          },
-                          "qualifiers": [
-                            {
-                              "kind": "ConceptQualifier",
-                              "type": "FormTitle",
-                              "valueType": "xs:string",
-                              "value": "stepSizeControlNeeded"
-                            },
-                            {
-                              "kind": "ConceptQualifier",
-                              "type": "FormInfo",
-                              "valueType": "xs:string",
-                              "value": "Solver with step size control recommended."
-                            },
-                            {
-                              "kind": "ConceptQualifier",
-                              "type": "PresetIdShort",
-                              "valueType": "xs:string",
-                              "value": "stepSizeControlNeeded"
-                            },
-                            {
-                              "kind": "ConceptQualifier",
-                              "type": "Multiplicity",
-                              "valueType": "xs:string",
-                              "value": "One"
-                            },
-                            {
-                              "kind": "ConceptQualifier",
-                              "type": "FormChoices",
-                              "valueType": "xs:string",
-                              "value": "True; False"
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
                             }
-                          ],
-                          "valueType": "xs:boolean",
-                          "modelType": "Property"
-                        },
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "de",
+                                "text": "Herstellerproduktbezeichnung"
+                            },
+                            {
+                                "language": "en",
+                                "text": "Manufacturer product designation"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "de",
+                                "text": "Kurze Beschreibung des Produktes (Kurztext)"
+                            },
+                            {
+                                "language": "en",
+                                "text": "Short description of the product (short text)"
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "ManProDes"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "TO_FIX",
+            "modelType": "ConceptDescription",
+            "id": "0173-1#02-AAW338#001",
+            "isCaseOf": [
+                {
+                    "type": "ExternalReference",
+                    "keys": [
                         {
-                          "idShort": "FixedStepSize",
-                          "semanticId": {
-                            "type": "ExternalReference",
-                            "keys": [
-                              {
+                            "type": "GlobalReference",
+                            "value": "0173-1#02-AAW338#001"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
                                 "type": "GlobalReference",
-                                "value": "https://admin-shell.io/idta/SimulationModels/FixedStepSize/1/0"
-                              }
-                            ]
-                          },
-                          "qualifiers": [
-                            {
-                              "kind": "ConceptQualifier",
-                              "type": "FormTitle",
-                              "valueType": "xs:string",
-                              "value": "fixedStepSize"
-                            },
-                            {
-                              "kind": "ConceptQualifier",
-                              "type": "FormInfo",
-                              "valueType": "xs:string",
-                              "value": "Fixed integration step size, if there is no adaptive step size "
-                            },
-                            {
-                              "kind": "ConceptQualifier",
-                              "type": "PresetIdShort",
-                              "valueType": "xs:string",
-                              "value": "fixedStepSize"
-                            },
-                            {
-                              "kind": "ConceptQualifier",
-                              "type": "Multiplicity",
-                              "valueType": "xs:string",
-                              "value": "ZeroToOne"
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
                             }
-                          ],
-                          "valueType": "xs:float",
-                          "modelType": "Property"
-                        },
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "Address"
+                            },
+                            {
+                                "language": "de",
+                                "text": "Adresse"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "Address information of a business partner"
+                            },
+                            {
+                                "language": "de",
+                                "text": "Adressinformationen zu einem Gesch\u00e4ftspartner"
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "Add"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "TO_FIX",
+            "modelType": "ConceptDescription",
+            "id": "0173-1#02-AAQ832#005",
+            "isCaseOf": [
+                {
+                    "type": "ExternalReference",
+                    "keys": [
                         {
-                          "idShort": "StiffSolverNeeded",
-                          "semanticId": {
-                            "type": "ExternalReference",
-                            "keys": [
-                              {
+                            "type": "GlobalReference",
+                            "value": "0173-1#02-AAQ832#005"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
                                 "type": "GlobalReference",
-                                "value": "https://admin-shell.io/idta/SimulationModels/StiffSolverNeeded/1/0"
-                              }
-                            ]
-                          },
-                          "qualifiers": [
-                            {
-                              "kind": "ConceptQualifier",
-                              "type": "FormTitle",
-                              "valueType": "xs:string",
-                              "value": "stiffSolverNeeded"
-                            },
-                            {
-                              "kind": "ConceptQualifier",
-                              "type": "FormInfo",
-                              "valueType": "xs:string",
-                              "value": "Stiff solver needed."
-                            },
-                            {
-                              "kind": "ConceptQualifier",
-                              "type": "PresetIdShort",
-                              "valueType": "xs:string",
-                              "value": "stiffSolverNeeded"
-                            },
-                            {
-                              "kind": "ConceptQualifier",
-                              "type": "Multiplicity",
-                              "valueType": "xs:string",
-                              "value": "One"
-                            },
-                            {
-                              "kind": "ConceptQualifier",
-                              "type": "FormChoices",
-                              "valueType": "xs:string",
-                              "value": "True; False"
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
                             }
-                          ],
-                          "valueType": "xs:boolean",
-                          "modelType": "Property"
-                        },
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "de",
+                                "text": "Abteilung"
+                            },
+                            {
+                                "language": "en",
+                                "text": "department"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "de",
+                                "text": "administrative Abteilung einer Organisation, in der ein Gesch\u00e4ftspartner vertreten ist"
+                            },
+                            {
+                                "language": "en",
+                                "text": "administrative section within an organization where a business partner is located"
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "Dep"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "TO_FIX",
+            "modelType": "ConceptDescription",
+            "id": "0173-1#02-AAO127#003",
+            "isCaseOf": [
+                {
+                    "type": "ExternalReference",
+                    "keys": [
                         {
-                          "idShort": "SolverIncluded",
-                          "semanticId": {
-                            "type": "ExternalReference",
-                            "keys": [
-                              {
+                            "type": "GlobalReference",
+                            "value": "0173-1#02-AAO127#003"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
                                 "type": "GlobalReference",
-                                "value": "https://admin-shell.io/idta/SimulationModels/SolverIncluded/1/0"
-                              }
-                            ]
-                          },
-                          "qualifiers": [
-                            {
-                              "kind": "ConceptQualifier",
-                              "type": "FormTitle",
-                              "valueType": "xs:string",
-                              "value": "solverIncluded"
-                            },
-                            {
-                              "kind": "ConceptQualifier",
-                              "type": "FormInfo",
-                              "valueType": "xs:string",
-                              "value": "Solver is integrated in the model (e.g. FMU for co-simulation)"
-                            },
-                            {
-                              "kind": "ConceptQualifier",
-                              "type": "PresetIdShort",
-                              "valueType": "xs:string",
-                              "value": "solverIncluded"
-                            },
-                            {
-                              "kind": "ConceptQualifier",
-                              "type": "Multiplicity",
-                              "valueType": "xs:string",
-                              "value": "One"
-                            },
-                            {
-                              "kind": "ConceptQualifier",
-                              "type": "FormChoices",
-                              "valueType": "xs:string",
-                              "value": "True; False"
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
                             }
-                          ],
-                          "valueType": "xs:boolean",
-                          "modelType": "Property"
-                        },
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "street"
+                            },
+                            {
+                                "language": "de",
+                                "text": "Stra\u00dfe"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "street name and house number"
+                            },
+                            {
+                                "language": "de",
+                                "text": "Stra\u00dfenname und Hausnummer"
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "Str"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "TO_FIX",
+            "modelType": "ConceptDescription",
+            "id": "0173-1#02-AAO128#002",
+            "isCaseOf": [
+                {
+                    "type": "ExternalReference",
+                    "keys": [
                         {
-                          "idShort": "TestedToolSolverAlgorithm",
-                          "semanticId": {
-                            "type": "ExternalReference",
-                            "keys": [
-                              {
+                            "type": "GlobalReference",
+                            "value": "0173-1#02-AAO128#002"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
                                 "type": "GlobalReference",
-                                "value": "https://admin-shell.io/idta/SimulationModels/TestedToolSolverAlgorithm/1/0"
-                              }
-                            ]
-                          },
-                          "qualifiers": [
-                            {
-                              "kind": "ConceptQualifier",
-                              "type": "FormTitle",
-                              "valueType": "xs:string",
-                              "value": "testedToolSolverAlgorithm"
-                            },
-                            {
-                              "kind": "ConceptQualifier",
-                              "type": "FormInfo",
-                              "valueType": "xs:string",
-                              "value": "List of validated tool-solver combinations"
-                            },
-                            {
-                              "kind": "ConceptQualifier",
-                              "type": "PresetIdShort",
-                              "valueType": "xs:string",
-                              "value": "testedToolSolverAlgorithm\u0027{0:00}\u0027"
-                            },
-                            {
-                              "kind": "ConceptQualifier",
-                              "type": "Multiplicity",
-                              "valueType": "xs:string",
-                              "value": "ZeroToMany"
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
                             }
-                          ],
-                          "value": [
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
                             {
-                              "idShort": "SolverAlgorithm",
-                              "semanticId": {
-                                "type": "ExternalReference",
-                                "keys": [
-                                  {
-                                    "type": "GlobalReference",
-                                    "value": "https://admin-shell.io/idta/SimulationModels/SolverAlgorithm/1/0"
-                                  }
-                                ]
-                              },
-                              "qualifiers": [
-                                {
-                                  "kind": "ConceptQualifier",
-                                  "type": "FormTitle",
-                                  "valueType": "xs:string",
-                                  "value": "solverAlgorithm"
-                                },
-                                {
-                                  "kind": "ConceptQualifier",
-                                  "type": "FormInfo",
-                                  "valueType": "xs:string",
-                                  "value": "validated solver"
-                                },
-                                {
-                                  "kind": "ConceptQualifier",
-                                  "type": "PresetIdShort",
-                                  "valueType": "xs:string",
-                                  "value": "solverAlgorithm"
-                                },
-                                {
-                                  "kind": "ConceptQualifier",
-                                  "type": "Multiplicity",
-                                  "valueType": "xs:string",
-                                  "value": "One"
-                                }
-                              ],
-                              "valueType": "xs:string",
-                              "modelType": "Property"
+                                "language": "en",
+                                "text": "zip code"
                             },
                             {
-                              "idShort": "ToolSolverFurtherDescription",
-                              "semanticId": {
-                                "type": "ExternalReference",
-                                "keys": [
-                                  {
-                                    "type": "GlobalReference",
-                                    "value": "https://admin-shell.io/idta/SimulationModels/ToolSolverFurtherDescription/1/0"
-                                  }
-                                ]
-                              },
-                              "qualifiers": [
-                                {
-                                  "kind": "ConceptQualifier",
-                                  "type": "FormTitle",
-                                  "valueType": "xs:string",
-                                  "value": "toolSolverFurtherDescription"
-                                },
-                                {
-                                  "kind": "ConceptQualifier",
-                                  "type": "FormInfo",
-                                  "valueType": "xs:string",
-                                  "value": "Further tool- and solver-specific information"
-                                },
-                                {
-                                  "kind": "ConceptQualifier",
-                                  "type": "PresetIdShort",
-                                  "valueType": "xs:string",
-                                  "value": "toolSolverFurtherDescription"
-                                },
-                                {
-                                  "kind": "ConceptQualifier",
-                                  "type": "Multiplicity",
-                                  "valueType": "xs:string",
-                                  "value": "ZeroToOne"
-                                }
-                              ],
-                              "valueType": "xs:string",
-                              "modelType": "Property"
-                            },
-                            {
-                              "idShort": "Tolerance",
-                              "semanticId": {
-                                "type": "ExternalReference",
-                                "keys": [
-                                  {
-                                    "type": "GlobalReference",
-                                    "value": "https://admin-shell.io/idta/SimulationModels/Tolerance/1/0"
-                                  }
-                                ]
-                              },
-                              "qualifiers": [
-                                {
-                                  "kind": "ConceptQualifier",
-                                  "type": "FormTitle",
-                                  "valueType": "xs:string",
-                                  "value": "tolerance"
-                                },
-                                {
-                                  "kind": "ConceptQualifier",
-                                  "type": "FormInfo",
-                                  "valueType": "xs:string",
-                                  "value": "(relative) tolerance for theadaptive step size "
-                                },
-                                {
-                                  "kind": "ConceptQualifier",
-                                  "type": "PresetIdShort",
-                                  "valueType": "xs:string",
-                                  "value": "tolerance"
-                                },
-                                {
-                                  "kind": "ConceptQualifier",
-                                  "type": "Multiplicity",
-                                  "valueType": "xs:string",
-                                  "value": "ZeroToOne"
-                                }
-                              ],
-                              "valueType": "xs:float",
-                              "modelType": "Property"
+                                "language": "de",
+                                "text": "Postleitzahl"
                             }
-                          ],
-                          "modelType": "SubmodelElementCollection"
-                        }
-                      ],
-                      "modelType": "SubmodelElementCollection"
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "ZIP code of address"
+                            },
+                            {
+                                "language": "de",
+                                "text": "Postleitzahl der Anschrift"
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "ZipCod"
+                            }
+                        ]
                     }
-                  ],
-                  "modelType": "SubmodelElementCollection"
                 }
-              ],
-              "modelType": "SubmodelElementCollection"
-            },
-            {
-              "idShort": "RefSimDocumentation",
-              "semanticId": {
-                "type": "ExternalReference",
-                "keys": [
-                  {
-                    "type": "GlobalReference",
-                    "value": "https://admin-shell.io/idta/SimulationModels/RefSimDocumentation/1/0"
-                  }
-                ]
-              },
-              "qualifiers": [
+            ],
+            "idShort": "TO_FIX",
+            "modelType": "ConceptDescription",
+            "id": "0173-1#02-AAO129#002",
+            "isCaseOf": [
                 {
-                  "kind": "ConceptQualifier",
-                  "type": "FormTitle",
-                  "valueType": "xs:string",
-                  "value": "refSimDocumentation"
-                },
-                {
-                  "kind": "ConceptQualifier",
-                  "type": "FormInfo",
-                  "valueType": "xs:string",
-                  "value": "Documentation of example simulations of the model can be supplied. This includes a solver setup and sample circuit and sample results. e.g. zip file, PDF, html, ..."
-                },
-                {
-                  "kind": "ConceptQualifier",
-                  "type": "PresetIdShort",
-                  "valueType": "xs:string",
-                  "value": "refSimDocumentation\u0027{0:00}\u0027"
-                },
-                {
-                  "kind": "ConceptQualifier",
-                  "type": "Multiplicity",
-                  "valueType": "xs:string",
-                  "value": "ZeroToMany"
-                }
-              ],
-              "contentType": "image/png",
-              "modelType": "File"
-            },
-            {
-              "category": "CONSTANT",
-              "idShort": "ModelFile",
-              "semanticId": {
-                "type": "ExternalReference",
-                "keys": [
-                  {
-                    "type": "GlobalReference",
-                    "value": "https://admin-shell.io/idta/SimulationModels/ModelFile/1/0"
-                  }
-                ]
-              },
-              "qualifiers": [
-                {
-                  "kind": "ConceptQualifier",
-                  "type": "FormTitle",
-                  "valueType": "xs:string",
-                  "value": "modelFile"
-                },
-                {
-                  "kind": "ConceptQualifier",
-                  "type": "FormInfo",
-                  "valueType": "xs:string",
-                  "value": "Providing versions of the simulation model and with characteristics to distinguish them."
-                },
-                {
-                  "kind": "ConceptQualifier",
-                  "type": "PresetIdShort",
-                  "valueType": "xs:string",
-                  "value": "modelFile"
-                },
-                {
-                  "kind": "ConceptQualifier",
-                  "type": "Multiplicity",
-                  "valueType": "xs:string",
-                  "value": "One"
-                }
-              ],
-              "value": [
-                {
-                  "idShort": "ModelFileType",
-                  "semanticId": {
                     "type": "ExternalReference",
                     "keys": [
-                      {
-                        "type": "GlobalReference",
-                        "value": "https://admin-shell.io/idta/SimulationModels/ModelFileType/1/0"
-                      }
+                        {
+                            "type": "GlobalReference",
+                            "value": "0173-1#02-AAO129#002"
+                        }
                     ]
-                  },
-                  "qualifiers": [
-                    {
-                      "kind": "ConceptQualifier",
-                      "type": "FormTitle",
-                      "valueType": "xs:string",
-                      "value": "modelFileType"
-                    },
-                    {
-                      "kind": "ConceptQualifier",
-                      "type": "FormInfo",
-                      "valueType": "xs:string",
-                      "value": "\u0022Designation of the exchange format of the model. E.G.: FMI 1.0, Co-Simulation, Platform / Source - Code. FMI 2.0.2, Model Exchange, Source - Code. S-function, Version 2, 64bit, mex - Format / or C-Code. Modelica 3, encoded. VHDL"
-                    },
-                    {
-                      "kind": "ConceptQualifier",
-                      "type": "PresetIdShort",
-                      "valueType": "xs:string",
-                      "value": "modelFileType"
-                    },
-                    {
-                      "kind": "ConceptQualifier",
-                      "type": "Multiplicity",
-                      "valueType": "xs:string",
-                      "value": "ZeroToOne"
-                    }
-                  ],
-                  "valueType": "xs:string",
-                  "modelType": "Property"
-                },
+                }
+            ]
+        },
+        {
+            "embeddedDataSpecifications": [
                 {
-                  "category": "CONSTANT",
-                  "idShort": "ModelFileVersion",
-                  "semanticId": {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "PO box"
+                            },
+                            {
+                                "language": "de",
+                                "text": "Postfach"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "P.O. box number"
+                            },
+                            {
+                                "language": "de",
+                                "text": "Nummer des Postfachs"
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "POBox"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "TO_FIX",
+            "modelType": "ConceptDescription",
+            "id": "0173-1#02-AAO130#002",
+            "isCaseOf": [
+                {
                     "type": "ExternalReference",
                     "keys": [
-                      {
-                        "type": "GlobalReference",
-                        "value": "https://admin-shell.io/idta/SimulationModels/ModelFileVersion/1/0"
-                      }
+                        {
+                            "type": "GlobalReference",
+                            "value": "0173-1#02-AAO130#002"
+                        }
                     ]
-                  },
-                  "qualifiers": [
-                    {
-                      "kind": "ConceptQualifier",
-                      "type": "FormTitle",
-                      "valueType": "xs:string",
-                      "value": "modelFileVersion"
+                }
+            ]
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
                     },
-                    {
-                      "kind": "ConceptQualifier",
-                      "type": "FormInfo",
-                      "valueType": "xs:string",
-                      "value": "Provision of a version of the simulation model with information to distinguish the versions. The versions are primarily intended for bug fixes without content changes."
-                    },
-                    {
-                      "kind": "ConceptQualifier",
-                      "type": "PresetIdShort",
-                      "valueType": "xs:string",
-                      "value": "modelFileVersion\u0027{0:00}\u0027"
-                    },
-                    {
-                      "kind": "ConceptQualifier",
-                      "type": "Multiplicity",
-                      "valueType": "xs:string",
-                      "value": "OneToMany"
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "zip code of PO box"
+                            },
+                            {
+                                "language": "de",
+                                "text": "Postleitzahl des Postfachs"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "ZIP code of P.O. box address"
+                            },
+                            {
+                                "language": "de",
+                                "text": "Postleitzahl der Postfachadresse"
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "ZipCodOfPOBox"
+                            }
+                        ]
                     }
-                  ],
-                  "value": [
-                    {
-                      "idShort": "ModelVersionId",
-                      "semanticId": {
-                        "type": "ExternalReference",
-                        "keys": [
-                          {
-                            "type": "GlobalReference",
-                            "value": "https://admin-shell.io/idta/SimulationModels/ModelVersionId/1/0"
-                          }
-                        ]
-                      },
-                      "qualifiers": [
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "FormTitle",
-                          "valueType": "xs:string",
-                          "value": "modelVersionId"
-                        },
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "FormInfo",
-                          "valueType": "xs:string",
-                          "value": "Version number of the model from the vendor."
-                        },
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "PresetIdShort",
-                          "valueType": "xs:string",
-                          "value": "modelVersionId"
-                        },
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "Multiplicity",
-                          "valueType": "xs:string",
-                          "value": "One"
-                        }
-                      ],
-                      "valueType": "xs:string",
-                      "modelType": "Property"
-                    },
-                    {
-                      "category": "CONSTANT",
-                      "idShort": "ModelPreviewImage",
-                      "semanticId": {
-                        "type": "ExternalReference",
-                        "keys": [
-                          {
-                            "type": "GlobalReference",
-                            "value": "https://admin-shell.io/idta/SimulationModels/ModelPreviewImage/1/0"
-                          }
-                        ]
-                      },
-                      "qualifiers": [
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "FormTitle",
-                          "valueType": "xs:string",
-                          "value": "modelPreviewImage"
-                        },
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "FormInfo",
-                          "valueType": "xs:string",
-                          "value": "Image file to represent the model in user interfaces, e.g. in a search."
-                        },
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "PresetIdShort",
-                          "valueType": "xs:string",
-                          "value": "modelPreviewImage"
-                        },
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "Multiplicity",
-                          "valueType": "xs:string",
-                          "value": "ZeroToOne"
-                        }
-                      ],
-                      "contentType": "image/png",
-                      "modelType": "File"
-                    },
-                    {
-                      "category": "CONSTANT",
-                      "idShort": "DigitalFile",
-                      "semanticId": {
-                        "type": "ExternalReference",
-                        "keys": [
-                          {
-                            "type": "GlobalReference",
-                            "value": "https://admin-shell.io/idta/SimulationModels/DigitalFile/1/0"
-                          }
-                        ]
-                      },
-                      "qualifiers": [
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "FormTitle",
-                          "valueType": "xs:string",
-                          "value": "digitalFile"
-                        },
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "FormInfo",
-                          "valueType": "xs:string",
-                          "value": "Deployment of the model file."
-                        },
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "PresetIdShort",
-                          "valueType": "xs:string",
-                          "value": "digitalFile"
-                        },
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "Multiplicity",
-                          "valueType": "xs:string",
-                          "value": "One"
-                        }
-                      ],
-                      "contentType": "image/png",
-                      "modelType": "File"
-                    },
-                    {
-                      "idShort": "ModelFileReleaseNotesTxt",
-                      "semanticId": {
-                        "type": "ExternalReference",
-                        "keys": [
-                          {
-                            "type": "GlobalReference",
-                            "value": "https://admin-shell.io/idta/SimulationModels/ModelFileReleaseNotesTxt/1/0"
-                          }
-                        ]
-                      },
-                      "qualifiers": [
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "FormTitle",
-                          "valueType": "xs:string",
-                          "value": "modelFileReleaseNotesTxt"
-                        },
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "FormInfo",
-                          "valueType": "xs:string",
-                          "value": "contains information about this release"
-                        },
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "PresetIdShort",
-                          "valueType": "xs:string",
-                          "value": "modelFileReleaseNotesTxt"
-                        },
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "Multiplicity",
-                          "valueType": "xs:string",
-                          "value": "ZeroToOne"
-                        }
-                      ],
-                      "modelType": "MultiLanguageProperty"
-                    },
-                    {
-                      "idShort": "ModelFileReleaseNotesFile",
-                      "semanticId": {
-                        "type": "ExternalReference",
-                        "keys": [
-                          {
-                            "type": "GlobalReference",
-                            "value": "https://admin-shell.io/idta/SimulationModels/ModelFileReleaseNotesFile/1/0"
-                          }
-                        ]
-                      },
-                      "qualifiers": [
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "FormTitle",
-                          "valueType": "xs:string",
-                          "value": "modelFileReleaseNotesFile"
-                        },
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "FormInfo",
-                          "valueType": "xs:string",
-                          "value": "release notes link or file"
-                        },
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "PresetIdShort",
-                          "valueType": "xs:string",
-                          "value": "modelFileReleaseNotesFile"
-                        },
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "Multiplicity",
-                          "valueType": "xs:string",
-                          "value": "ZeroToOne"
-                        }
-                      ],
-                      "contentType": "image/png",
-                      "modelType": "File"
-                    }
-                  ],
-                  "modelType": "SubmodelElementCollection"
                 }
-              ],
-              "modelType": "SubmodelElementCollection"
-            },
-            {
-              "idShort": "ParamMethod",
-              "semanticId": {
-                "type": "ExternalReference",
-                "keys": [
-                  {
-                    "type": "GlobalReference",
-                    "value": "https://admin-shell.io/idta/SimulationModels/ParamMethod/1/0"
-                  }
-                ]
-              },
-              "qualifiers": [
+            ],
+            "idShort": "TO_FIX",
+            "modelType": "ConceptDescription",
+            "id": "0173-1#02-AAO131#002",
+            "isCaseOf": [
                 {
-                  "kind": "ConceptQualifier",
-                  "type": "FormTitle",
-                  "valueType": "xs:string",
-                  "value": "paramMethod"
-                },
-                {
-                  "kind": "ConceptQualifier",
-                  "type": "FormInfo",
-                  "valueType": "xs:string",
-                  "value": "Indicates whether the model must be parameterized and if so, which method is required."
-                },
-                {
-                  "kind": "ConceptQualifier",
-                  "type": "PresetIdShort",
-                  "valueType": "xs:string",
-                  "value": "paramMethod"
-                },
-                {
-                  "kind": "ConceptQualifier",
-                  "type": "Multiplicity",
-                  "valueType": "xs:string",
-                  "value": "One"
-                },
-                {
-                  "kind": "ConceptQualifier",
-                  "type": "FormChoices",
-                  "valueType": "xs:string",
-                  "value": "by using \u0022technical data\u0022 of asset; by using \u0022technical data\u0022 and user; by user interface; by setting file; not necessary; by documentation file; pre-parametrized"
-                }
-              ],
-              "valueType": "xs:string",
-              "modelType": "Property"
-            },
-            {
-              "idShort": "ParamFile",
-              "semanticId": {
-                "type": "ExternalReference",
-                "keys": [
-                  {
-                    "type": "GlobalReference",
-                    "value": "https://admin-shell.io/idta/SimulationModels/ParamFile/1/0"
-                  }
-                ]
-              },
-              "qualifiers": [
-                {
-                  "kind": "ConceptQualifier",
-                  "type": "FormTitle",
-                  "valueType": "xs:string",
-                  "value": "paramFile"
-                },
-                {
-                  "kind": "ConceptQualifier",
-                  "type": "FormInfo",
-                  "valueType": "xs:string",
-                  "value": "File for parameterization of the model. As parameter file or parameter documentation (e.g. pdf). "
-                },
-                {
-                  "kind": "ConceptQualifier",
-                  "type": "PresetIdShort",
-                  "valueType": "xs:string",
-                  "value": "paramFile"
-                },
-                {
-                  "kind": "ConceptQualifier",
-                  "type": "Multiplicity",
-                  "valueType": "xs:string",
-                  "value": "ZeroToOne"
-                }
-              ],
-              "contentType": "image/png",
-              "modelType": "File"
-            },
-            {
-              "idShort": "InitStateMethod",
-              "semanticId": {
-                "type": "ExternalReference",
-                "keys": [
-                  {
-                    "type": "GlobalReference",
-                    "value": "https://admin-shell.io/idta/SimulationModels/InitStateMethod/1/0"
-                  }
-                ]
-              },
-              "qualifiers": [
-                {
-                  "kind": "ConceptQualifier",
-                  "type": "FormTitle",
-                  "valueType": "xs:string",
-                  "value": "initStateMethod"
-                },
-                {
-                  "kind": "ConceptQualifier",
-                  "type": "FormInfo",
-                  "valueType": "xs:string",
-                  "value": "\u0022 Describes the state variables of the simulation model that must be initialized to start the simulation. For initial value problems, these quantities describe the system state at the start of the simulation. In this case, the system is in a state of equilibrium. Alternatively, a simulation model may include a method to determine consistent initial values at this step, e.g., at an operating point. "
-                },
-                {
-                  "kind": "ConceptQualifier",
-                  "type": "PresetIdShort",
-                  "valueType": "xs:string",
-                  "value": "initStateMethod"
-                },
-                {
-                  "kind": "ConceptQualifier",
-                  "type": "Multiplicity",
-                  "valueType": "xs:string",
-                  "value": "One"
-                },
-                {
-                  "kind": "ConceptQualifier",
-                  "type": "FormChoices",
-                  "valueType": "xs:string",
-                  "value": "not necessary, by user interface; by setting file; set states within simulation environment; integrated in model; by documentation file"
-                }
-              ],
-              "valueType": "xs:string",
-              "modelType": "Property"
-            },
-            {
-              "idShort": "InitStateFile",
-              "semanticId": {
-                "type": "ExternalReference",
-                "keys": [
-                  {
-                    "type": "GlobalReference",
-                    "value": "https://admin-shell.io/idta/SimulationModels/InitStateFile/1/0"
-                  }
-                ]
-              },
-              "qualifiers": [
-                {
-                  "kind": "ConceptQualifier",
-                  "type": "FormTitle",
-                  "valueType": "xs:string",
-                  "value": "initStateFile"
-                },
-                {
-                  "kind": "ConceptQualifier",
-                  "type": "FormInfo",
-                  "valueType": "xs:string",
-                  "value": "File for parameterizing the initial states of the model. As parameter file or parameter documentation (e.g. pdf). "
-                },
-                {
-                  "kind": "ConceptQualifier",
-                  "type": "PresetIdShort",
-                  "valueType": "xs:string",
-                  "value": "initStateFile"
-                },
-                {
-                  "kind": "ConceptQualifier",
-                  "type": "Multiplicity",
-                  "valueType": "xs:string",
-                  "value": "ZeroToOne"
-                }
-              ],
-              "contentType": "image/png",
-              "modelType": "File"
-            },
-            {
-              "idShort": "DefaultSimTime",
-              "semanticId": {
-                "type": "ExternalReference",
-                "keys": [
-                  {
-                    "type": "GlobalReference",
-                    "value": "https://admin-shell.io/idta/SimulationModels/DefaultSimTime/1/0"
-                  }
-                ]
-              },
-              "qualifiers": [
-                {
-                  "kind": "ConceptQualifier",
-                  "type": "FormTitle",
-                  "valueType": "xs:string",
-                  "value": "defaultSimTime"
-                },
-                {
-                  "kind": "ConceptQualifier",
-                  "type": "FormInfo",
-                  "valueType": "xs:string",
-                  "value": "Predefined simulation period in seconds "
-                },
-                {
-                  "kind": "ConceptQualifier",
-                  "type": "PresetIdShort",
-                  "valueType": "xs:string",
-                  "value": "defaultSimTime"
-                },
-                {
-                  "kind": "ConceptQualifier",
-                  "type": "Multiplicity",
-                  "valueType": "xs:string",
-                  "value": "ZeroToOne"
-                }
-              ],
-              "valueType": "xs:float",
-              "modelType": "Property"
-            },
-            {
-              "category": "CONSTANT",
-              "idShort": "SimModManufacturerInformation",
-              "semanticId": {
-                "type": "ExternalReference",
-                "keys": [
-                  {
-                    "type": "GlobalReference",
-                    "value": "https://admin-shell.io/idta/SimulationModels/SimModManufacturerInformation/1/0"
-                  }
-                ]
-              },
-              "qualifiers": [
-                {
-                  "kind": "ConceptQualifier",
-                  "type": "FormTitle",
-                  "valueType": "xs:string",
-                  "value": "simModManufacturerInformation"
-                },
-                {
-                  "kind": "ConceptQualifier",
-                  "type": "FormInfo",
-                  "valueType": "xs:string",
-                  "value": "Provide access to  simulation support service provided by the distributor via mail or phone"
-                },
-                {
-                  "kind": "ConceptQualifier",
-                  "type": "PresetIdShort",
-                  "valueType": "xs:string",
-                  "value": "simModManufacturerInformation\u0027{0:00}\u0027"
-                },
-                {
-                  "kind": "ConceptQualifier",
-                  "type": "Multiplicity",
-                  "valueType": "xs:string",
-                  "value": "ZeroToMany"
-                }
-              ],
-              "value": [
-                {
-                  "idShort": "Company",
-                  "semanticId": {
                     "type": "ExternalReference",
                     "keys": [
-                      {
-                        "type": "GlobalReference",
-                        "value": "0173-1#02-AAW001#001"
-                      }
+                        {
+                            "type": "GlobalReference",
+                            "value": "0173-1#02-AAO131#002"
+                        }
                     ]
-                  },
-                  "qualifiers": [
-                    {
-                      "kind": "ConceptQualifier",
-                      "type": "FormTitle",
-                      "valueType": "xs:string",
-                      "value": "company"
-                    },
-                    {
-                      "kind": "ConceptQualifier",
-                      "type": "FormInfo",
-                      "valueType": "xs:string",
-                      "value": "name of the company"
-                    },
-                    {
-                      "kind": "ConceptQualifier",
-                      "type": "PresetIdShort",
-                      "valueType": "xs:string",
-                      "value": "company"
-                    },
-                    {
-                      "kind": "ConceptQualifier",
-                      "type": "Multiplicity",
-                      "valueType": "xs:string",
-                      "value": "One"
-                    }
-                  ],
-                  "valueType": "xs:string",
-                  "modelType": "Property"
-                },
+                }
+            ]
+        },
+        {
+            "embeddedDataSpecifications": [
                 {
-                  "idShort": "Language",
-                  "semanticId": {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "city/town"
+                            },
+                            {
+                                "language": "de",
+                                "text": "Ort"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "town or city"
+                            },
+                            {
+                                "language": "de",
+                                "text": "Ortsangabe"
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "CitTow"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "TO_FIX",
+            "modelType": "ConceptDescription",
+            "id": "0173-1#02-AAO132#002",
+            "isCaseOf": [
+                {
                     "type": "ExternalReference",
                     "keys": [
-                      {
-                        "type": "GlobalReference",
-                        "value": "0173-1#02-AAO895#003"
-                      }
+                        {
+                            "type": "GlobalReference",
+                            "value": "0173-1#02-AAO132#002"
+                        }
                     ]
-                  },
-                  "qualifiers": [
-                    {
-                      "kind": "ConceptQualifier",
-                      "type": "FormTitle",
-                      "valueType": "xs:string",
-                      "value": "language"
-                    },
-                    {
-                      "kind": "ConceptQualifier",
-                      "type": "FormInfo",
-                      "valueType": "xs:string",
-                      "value": "available language"
-                    },
-                    {
-                      "kind": "ConceptQualifier",
-                      "type": "PresetIdShort",
-                      "valueType": "xs:string",
-                      "value": "language\u0027{0:00}\u0027"
-                    },
-                    {
-                      "kind": "ConceptQualifier",
-                      "type": "Multiplicity",
-                      "valueType": "xs:string",
-                      "value": "OneToMany"
-                    }
-                  ],
-                  "valueType": "xs:string",
-                  "modelType": "Property"
-                },
+                }
+            ]
+        },
+        {
+            "embeddedDataSpecifications": [
                 {
-                  "idShort": "Email",
-                  "semanticId": {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "state/county"
+                            },
+                            {
+                                "language": "de",
+                                "text": "Bundesland"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "federal state a part of a state"
+                            },
+                            {
+                                "language": "de",
+                                "text": "Teil eines Bundesstaats"
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "StaCou"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "TO_FIX",
+            "modelType": "ConceptDescription",
+            "id": "0173-1#02-AAO133#002",
+            "isCaseOf": [
+                {
                     "type": "ExternalReference",
                     "keys": [
-                      {
-                        "type": "GlobalReference",
-                        "value": "0173-1#02-AAQ836#005"
-                      }
+                        {
+                            "type": "GlobalReference",
+                            "value": "0173-1#02-AAO133#002"
+                        }
                     ]
-                  },
-                  "qualifiers": [
-                    {
-                      "kind": "ConceptQualifier",
-                      "type": "FormTitle",
-                      "valueType": "xs:string",
-                      "value": "email"
-                    },
-                    {
-                      "kind": "ConceptQualifier",
-                      "type": "FormInfo",
-                      "valueType": "xs:string",
-                      "value": "E-mail address and encryption method"
-                    },
-                    {
-                      "kind": "ConceptQualifier",
-                      "type": "PresetIdShort",
-                      "valueType": "xs:string",
-                      "value": "email"
-                    },
-                    {
-                      "kind": "ConceptQualifier",
-                      "type": "Multiplicity",
-                      "valueType": "xs:string",
-                      "value": "ZeroToOne"
-                    }
-                  ],
-                  "value": [
-                    {
-                      "idShort": "TypeOfEmailAddress",
-                      "semanticId": {
-                        "type": "ExternalReference",
-                        "keys": [
-                          {
-                            "type": "GlobalReference",
-                            "value": "0173-1#02-AAO199#003"
-                          }
-                        ]
-                      },
-                      "qualifiers": [
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "FormTitle",
-                          "valueType": "xs:string",
-                          "value": "typeOfEmailAddress"
-                        },
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "FormInfo",
-                          "valueType": "xs:string",
-                          "value": "characterization of an e-mail address according to its location or usage"
-                        },
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "PresetIdShort",
-                          "valueType": "xs:string",
-                          "value": "typeOfEmailAddress"
-                        },
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "Multiplicity",
-                          "valueType": "xs:string",
-                          "value": "ZeroToOne"
-                        }
-                      ],
-                      "valueType": "xs:string",
-                      "modelType": "Property"
-                    },
-                    {
-                      "idShort": "EmailAddress",
-                      "semanticId": {
-                        "type": "ExternalReference",
-                        "keys": [
-                          {
-                            "type": "GlobalReference",
-                            "value": "0173-1#02-AAO198#002"
-                          }
-                        ]
-                      },
-                      "qualifiers": [
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "FormTitle",
-                          "valueType": "xs:string",
-                          "value": "emailAddress"
-                        },
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "FormInfo",
-                          "valueType": "xs:string",
-                          "value": "electronic mail address of a business partner"
-                        },
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "PresetIdShort",
-                          "valueType": "xs:string",
-                          "value": "emailAddress"
-                        },
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "Multiplicity",
-                          "valueType": "xs:string",
-                          "value": "One"
-                        }
-                      ],
-                      "valueType": "xs:string",
-                      "modelType": "Property"
-                    },
-                    {
-                      "idShort": "TypeOfPublicKey",
-                      "semanticId": {
-                        "type": "ExternalReference",
-                        "keys": [
-                          {
-                            "type": "GlobalReference",
-                            "value": "0173-1#02-AAO201#002"
-                          }
-                        ]
-                      },
-                      "qualifiers": [
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "FormTitle",
-                          "valueType": "xs:string",
-                          "value": "typeOfPublicKey"
-                        },
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "FormInfo",
-                          "valueType": "xs:string",
-                          "value": "characterization of a public key according to its encryption process"
-                        },
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "PresetIdShort",
-                          "valueType": "xs:string",
-                          "value": "typeOfPublicKey"
-                        },
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "Multiplicity",
-                          "valueType": "xs:string",
-                          "value": "ZeroToOne"
-                        }
-                      ],
-                      "valueType": "xs:string",
-                      "modelType": "Property"
-                    },
-                    {
-                      "idShort": "PublicKey",
-                      "semanticId": {
-                        "type": "ExternalReference",
-                        "keys": [
-                          {
-                            "type": "GlobalReference",
-                            "value": "0173-1#02-AAO200#002"
-                          }
-                        ]
-                      },
-                      "qualifiers": [
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "FormTitle",
-                          "valueType": "xs:string",
-                          "value": "publicKey"
-                        },
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "FormInfo",
-                          "valueType": "xs:string",
-                          "value": "public part of an unsymmetrical key pair to sign or encrypt text or messages"
-                        },
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "PresetIdShort",
-                          "valueType": "xs:string",
-                          "value": "publicKey"
-                        },
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "Multiplicity",
-                          "valueType": "xs:string",
-                          "value": "ZeroToOne"
-                        }
-                      ],
-                      "valueType": "xs:string",
-                      "modelType": "Property"
-                    }
-                  ],
-                  "modelType": "SubmodelElementCollection"
-                },
+                }
+            ]
+        },
+        {
+            "embeddedDataSpecifications": [
                 {
-                  "idShort": "Phone",
-                  "semanticId": {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "national code"
+                            },
+                            {
+                                "language": "de",
+                                "text": "L\u00e4ndercode"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "code of a country"
+                            },
+                            {
+                                "language": "de",
+                                "text": "Code eines Landes"
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "NatCod"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "TO_FIX",
+            "modelType": "ConceptDescription",
+            "id": "0173-1#02-AAO134#002",
+            "isCaseOf": [
+                {
                     "type": "ExternalReference",
                     "keys": [
-                      {
-                        "type": "GlobalReference",
-                        "value": "https://admin-shell.io/zvei/nameplate/1/0/ContactInformations/ContactInformation/Phone"
-                      }
-                    ]
-                  },
-                  "qualifiers": [
-                    {
-                      "kind": "ConceptQualifier",
-                      "type": "FormTitle",
-                      "valueType": "xs:string",
-                      "value": "phone"
-                    },
-                    {
-                      "kind": "ConceptQualifier",
-                      "type": "FormInfo",
-                      "valueType": "xs:string",
-                      "value": "Phone number including type"
-                    },
-                    {
-                      "kind": "ConceptQualifier",
-                      "type": "PresetIdShort",
-                      "valueType": "xs:string",
-                      "value": "phone"
-                    },
-                    {
-                      "kind": "ConceptQualifier",
-                      "type": "Multiplicity",
-                      "valueType": "xs:string",
-                      "value": "ZeroToOne"
-                    }
-                  ],
-                  "value": [
-                    {
-                      "idShort": "TypeOfTelephone",
-                      "semanticId": {
-                        "type": "ExternalReference",
-                        "keys": [
-                          {
+                        {
                             "type": "GlobalReference",
-                            "value": "0173-1#02-AAO137#003"
-                          }
-                        ]
-                      },
-                      "qualifiers": [
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "FormTitle",
-                          "valueType": "xs:string",
-                          "value": "typeOfTelephone"
-                        },
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "FormInfo",
-                          "valueType": "xs:string",
-                          "value": "characterization of a telephone according to its location or usage"
-                        },
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "PresetIdShort",
-                          "valueType": "xs:string",
-                          "value": "typeOfTelephone"
-                        },
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "Multiplicity",
-                          "valueType": "xs:string",
-                          "value": "ZeroToOne"
+                            "value": "0173-1#02-AAO134#002"
                         }
-                      ],
-                      "valueType": "xs:string",
-                      "modelType": "Property"
-                    },
-                    {
-                      "idShort": "TelephoneNumber",
-                      "semanticId": {
+                    ]
+                }
+            ]
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
                         "type": "ExternalReference",
                         "keys": [
-                          {
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "VAT number"
+                            },
+                            {
+                                "language": "de",
+                                "text": "Umsatzsteuer-ID"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "VAT identification number of the business partner"
+                            },
+                            {
+                                "language": "de",
+                                "text": "Umsatzsteuer-ID des Gesch\u00e4ftspartners"
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "VATNum"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "TO_FIX",
+            "modelType": "ConceptDescription",
+            "id": "0173-1#02-AAO135#002",
+            "isCaseOf": [
+                {
+                    "type": "ExternalReference",
+                    "keys": [
+                        {
+                            "type": "GlobalReference",
+                            "value": "0173-1#02-AAO135#002"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "address remarks"
+                            },
+                            {
+                                "language": "de",
+                                "text": "Anmerkungen zu Adresse"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "plain text characterizing address information for which there is no property"
+                            },
+                            {
+                                "language": "de",
+                                "text": "einfacher Text, der Adressinformationen kennzeichnet, bei denen kein Merkmal zur Verf\u00fcgung steht"
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "AddRem"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "TO_FIX",
+            "modelType": "ConceptDescription",
+            "id": "0173-1#02-AAO202#003",
+            "isCaseOf": [
+                {
+                    "type": "ExternalReference",
+                    "keys": [
+                        {
+                            "type": "GlobalReference",
+                            "value": "0173-1#02-AAO202#003"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "address of additional link"
+                            },
+                            {
+                                "language": "de",
+                                "text": "zus\u00e4tzlicher Online-Verweis"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "web site address where information about the product or contact is given"
+                            },
+                            {
+                                "language": "de",
+                                "text": "Angabe einer Web-Adresse, die zus\u00e4tzliche Informationen zum Produkt oder Kontaktdaten enth\u00e4lt"
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "AddOfAddLin"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "TO_FIX",
+            "modelType": "ConceptDescription",
+            "id": "0173-1#02-AAQ326#002",
+            "isCaseOf": [
+                {
+                    "type": "ExternalReference",
+                    "keys": [
+                        {
+                            "type": "GlobalReference",
+                            "value": "0173-1#02-AAQ326#002"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "Phone"
+                            },
+                            {
+                                "language": "de",
+                                "text": "Telefon"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "Phone number including type"
+                            },
+                            {
+                                "language": "de",
+                                "text": "Telefonnummer mit Angabe der Art des Anschlusses"
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "Pho"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "TO_FIX",
+            "modelType": "ConceptDescription",
+            "id": "0173-1#02-AAQ833#005",
+            "isCaseOf": [
+                {
+                    "type": "ExternalReference",
+                    "keys": [
+                        {
+                            "type": "GlobalReference",
+                            "value": "0173-1#02-AAQ833#005"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "telephone number"
+                            },
+                            {
+                                "language": "de",
+                                "text": "Telefonnummer"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "complete telephone number to be called to reach a business partner"
+                            },
+                            {
+                                "language": "de",
+                                "text": "vollst\u00e4ndige Telefonnummer, unter der ein Gesch\u00e4ftspartner erreichbar ist"
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "TelNum"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "TO_FIX",
+            "modelType": "ConceptDescription",
+            "id": "0173-1#02-AAO136#002",
+            "isCaseOf": [
+                {
+                    "type": "ExternalReference",
+                    "keys": [
+                        {
                             "type": "GlobalReference",
                             "value": "0173-1#02-AAO136#002"
-                          }
-                        ]
-                      },
-                      "qualifiers": [
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "FormTitle",
-                          "valueType": "xs:string",
-                          "value": "telephoneNumber"
-                        },
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "FormInfo",
-                          "valueType": "xs:string",
-                          "value": "complete telephone number to be called to reach a business partner"
-                        },
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "PresetIdShort",
-                          "valueType": "xs:string",
-                          "value": "telephoneNumber"
-                        },
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "Multiplicity",
-                          "valueType": "xs:string",
-                          "value": "One"
                         }
-                      ],
-                      "valueType": "xs:string",
-                      "modelType": "Property"
-                    },
-                    {
-                      "idShort": "AvailableTime",
-                      "semanticId": {
+                    ]
+                }
+            ]
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
                         "type": "ExternalReference",
                         "keys": [
-                          {
-                            "type": "GlobalReference",
-                            "value": "https://admin-shell.io/zvei/nameplate/1/0/ContactInformations/ContactInformation/AvailableTime/"
-                          }
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
                         ]
-                      },
-                      "qualifiers": [
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "FormTitle",
-                          "valueType": "xs:string",
-                          "value": "availableTime"
-                        },
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "FormInfo",
-                          "valueType": "xs:string",
-                          "value": "Specification of the available time window"
-                        },
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "PresetIdShort",
-                          "valueType": "xs:string",
-                          "value": "availableTime"
-                        },
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "Multiplicity",
-                          "valueType": "xs:string",
-                          "value": "ZeroToOne"
-                        }
-                      ],
-                      "valueType": "xs:string",
-                      "modelType": "Property"
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "Fax"
+                            },
+                            {
+                                "language": "de",
+                                "text": "Fax"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "Fax number including type"
+                            },
+                            {
+                                "language": "de",
+                                "text": "Faxnummer mit Angabe der Art des Anschlusses"
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "Fax"
+                            }
+                        ]
                     }
-                  ],
-                  "modelType": "SubmodelElementCollection"
                 }
-              ],
-              "modelType": "SubmodelElementCollection"
-            },
-            {
-              "idShort": "Ports",
-              "semanticId": {
-                "type": "ExternalReference",
-                "keys": [
-                  {
-                    "type": "GlobalReference",
-                    "value": "https://admin-shell.io/idta/SimulationModels/Ports/1/0"
-                  }
-                ]
-              },
-              "qualifiers": [
+            ],
+            "idShort": "TO_FIX",
+            "modelType": "ConceptDescription",
+            "id": "0173-1#02-AAQ834#005",
+            "isCaseOf": [
                 {
-                  "kind": "ConceptQualifier",
-                  "type": "FormTitle",
-                  "valueType": "xs:string",
-                  "value": "ports"
-                },
-                {
-                  "kind": "ConceptQualifier",
-                  "type": "FormInfo",
-                  "valueType": "xs:string",
-                  "value": "Interfaces of the model. This includes inputs, outputs as well as acausal connections (e.g. mechanical connections). In addition, it is specified here whether the model provides binary interfaces (e.g. for visualization)."
-                },
-                {
-                  "kind": "ConceptQualifier",
-                  "type": "PresetIdShort",
-                  "valueType": "xs:string",
-                  "value": "ports"
-                },
-                {
-                  "kind": "ConceptQualifier",
-                  "type": "Multiplicity",
-                  "valueType": "xs:string",
-                  "value": "ZeroToOne"
-                }
-              ],
-              "value": [
-                {
-                  "idShort": "PortsConnector",
-                  "semanticId": {
                     "type": "ExternalReference",
                     "keys": [
-                      {
-                        "type": "GlobalReference",
-                        "value": "https://admin-shell.io/idta/SimulationModels/PortsConnector/1/0"
-                      }
+                        {
+                            "type": "GlobalReference",
+                            "value": "0173-1#02-AAQ834#005"
+                        }
                     ]
-                  },
-                  "qualifiers": [
-                    {
-                      "kind": "ConceptQualifier",
-                      "type": "FormTitle",
-                      "valueType": "xs:string",
-                      "value": "portsConnector"
-                    },
-                    {
-                      "kind": "ConceptQualifier",
-                      "type": "FormInfo",
-                      "valueType": "xs:string",
-                      "value": "List of ports of the model. These include a name, a description, a list of variables, and a list of ports."
-                    },
-                    {
-                      "kind": "ConceptQualifier",
-                      "type": "PresetIdShort",
-                      "valueType": "xs:string",
-                      "value": "portsConnector\u0027{0:00}\u0027"
-                    },
-                    {
-                      "kind": "ConceptQualifier",
-                      "type": "Multiplicity",
-                      "valueType": "xs:string",
-                      "value": "ZeroToMany"
-                    }
-                  ],
-                  "value": [
-                    {
-                      "idShort": "PortConnectorName",
-                      "semanticId": {
-                        "type": "ExternalReference",
-                        "keys": [
-                          {
-                            "type": "GlobalReference",
-                            "value": "https://admin-shell.io/idta/SimulationModels/PortsConnectorName/1/0"
-                          }
-                        ]
-                      },
-                      "qualifiers": [
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "FormTitle",
-                          "valueType": "xs:string",
-                          "value": "portConnectorName"
-                        },
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "FormInfo",
-                          "valueType": "xs:string",
-                          "value": "Name of the Connector Port."
-                        },
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "PresetIdShort",
-                          "valueType": "xs:string",
-                          "value": "portConnectorName"
-                        },
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "Multiplicity",
-                          "valueType": "xs:string",
-                          "value": "One"
-                        }
-                      ],
-                      "valueType": "xs:string",
-                      "modelType": "Property"
-                    },
-                    {
-                      "idShort": "PortConDescription",
-                      "semanticId": {
-                        "type": "ExternalReference",
-                        "keys": [
-                          {
-                            "type": "GlobalReference",
-                            "value": "https://admin-shell.io/idta/SimulationModel/portConDescription/1/0"
-                          }
-                        ]
-                      },
-                      "qualifiers": [
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "FormTitle",
-                          "valueType": "xs:string",
-                          "value": "portConDescription"
-                        },
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "FormInfo",
-                          "valueType": "xs:string",
-                          "value": "Description of the Connector Port."
-                        },
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "PresetIdShort",
-                          "valueType": "xs:string",
-                          "value": "portConDescription"
-                        },
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "Multiplicity",
-                          "valueType": "xs:string",
-                          "value": "ZeroToOne"
-                        }
-                      ],
-                      "modelType": "MultiLanguageProperty"
-                    },
-                    {
-                      "idShort": "Variable",
-                      "semanticId": {
-                        "type": "ExternalReference",
-                        "keys": [
-                          {
-                            "type": "GlobalReference",
-                            "value": "https://admin-shell.io/idta/SimulationModels/Variable/1/0"
-                          }
-                        ]
-                      },
-                      "qualifiers": [
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "FormTitle",
-                          "valueType": "xs:string",
-                          "value": "variable"
-                        },
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "FormInfo",
-                          "valueType": "xs:string",
-                          "value": "List of variables of the port."
-                        },
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "PresetIdShort",
-                          "valueType": "xs:string",
-                          "value": "variable{0:00}"
-                        },
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "Multiplicity",
-                          "valueType": "xs:string",
-                          "value": "ZeroToMany"
-                        }
-                      ],
-                      "value": [
-                        {
-                          "idShort": "VariableName",
-                          "semanticId": {
-                            "type": "ExternalReference",
-                            "keys": [
-                              {
-                                "type": "GlobalReference",
-                                "value": "https://admin-shell.io/idta/SimulationModels/VariableName/1/0"
-                              }
-                            ]
-                          },
-                          "qualifiers": [
-                            {
-                              "kind": "ConceptQualifier",
-                              "type": "FormTitle",
-                              "valueType": "xs:string",
-                              "value": "variableName"
-                            },
-                            {
-                              "kind": "ConceptQualifier",
-                              "type": "FormInfo",
-                              "valueType": "xs:string",
-                              "value": "Name of the variable."
-                            },
-                            {
-                              "kind": "ConceptQualifier",
-                              "type": "PresetIdShort",
-                              "valueType": "xs:string",
-                              "value": "variableName"
-                            },
-                            {
-                              "kind": "ConceptQualifier",
-                              "type": "Multiplicity",
-                              "valueType": "xs:string",
-                              "value": "One"
-                            }
-                          ],
-                          "valueType": "xs:string",
-                          "modelType": "Property"
-                        },
-                        {
-                          "idShort": "Range",
-                          "semanticId": {
-                            "type": "ExternalReference",
-                            "keys": [
-                              {
-                                "type": "GlobalReference",
-                                "value": "https://admin-shell.io/idta/SimulationModels/Range/1/0"
-                              }
-                            ]
-                          },
-                          "qualifiers": [
-                            {
-                              "kind": "ConceptQualifier",
-                              "type": "FormTitle",
-                              "valueType": "xs:string",
-                              "value": "range"
-                            },
-                            {
-                              "kind": "ConceptQualifier",
-                              "type": "FormInfo",
-                              "valueType": "xs:string",
-                              "value": "Range of values for the variable (e.g. [min, max], [min, max[, ]min, max], ]min, max[, {val1, val2, ...})."
-                            },
-                            {
-                              "kind": "ConceptQualifier",
-                              "type": "PresetIdShort",
-                              "valueType": "xs:string",
-                              "value": "range"
-                            },
-                            {
-                              "kind": "ConceptQualifier",
-                              "type": "Multiplicity",
-                              "valueType": "xs:string",
-                              "value": "ZeroToOne"
-                            }
-                          ],
-                          "valueType": "xs:string",
-                          "modelType": "Property"
-                        },
-                        {
-                          "idShort": "VariableType",
-                          "semanticId": {
-                            "type": "ExternalReference",
-                            "keys": [
-                              {
-                                "type": "GlobalReference",
-                                "value": "https://admin-shell.io/idta/SimulationModels/VariableType/1/0"
-                              }
-                            ]
-                          },
-                          "qualifiers": [
-                            {
-                              "kind": "ConceptQualifier",
-                              "type": "FormTitle",
-                              "valueType": "xs:string",
-                              "value": "variableType"
-                            },
-                            {
-                              "kind": "ConceptQualifier",
-                              "type": "FormInfo",
-                              "valueType": "xs:string",
-                              "value": "Type of the variable (e.g. Real, Integer, Boolean, String or Enum)."
-                            },
-                            {
-                              "kind": "ConceptQualifier",
-                              "type": "PresetIdShort",
-                              "valueType": "xs:string",
-                              "value": "variableType"
-                            },
-                            {
-                              "kind": "ConceptQualifier",
-                              "type": "Multiplicity",
-                              "valueType": "xs:string",
-                              "value": "One"
-                            },
-                            {
-                              "kind": "ConceptQualifier",
-                              "type": "FormChoices",
-                              "valueType": "xs:string",
-                              "value": "Real; Integer; Boolean; String; ENUM"
-                            }
-                          ],
-                          "valueType": "xs:string",
-                          "modelType": "Property"
-                        },
-                        {
-                          "idShort": "VariableDescription",
-                          "semanticId": {
-                            "type": "ExternalReference",
-                            "keys": [
-                              {
-                                "type": "GlobalReference",
-                                "value": "https://admin-shell.io/idta/SimulationModels/VariableDescription/1/0"
-                              }
-                            ]
-                          },
-                          "qualifiers": [
-                            {
-                              "kind": "ConceptQualifier",
-                              "type": "FormTitle",
-                              "valueType": "xs:string",
-                              "value": "variableDescription"
-                            },
-                            {
-                              "kind": "ConceptQualifier",
-                              "type": "FormInfo",
-                              "valueType": "xs:string",
-                              "value": "Description of the variable."
-                            },
-                            {
-                              "kind": "ConceptQualifier",
-                              "type": "PresetIdShort",
-                              "valueType": "xs:string",
-                              "value": "variableDescription"
-                            },
-                            {
-                              "kind": "ConceptQualifier",
-                              "type": "Multiplicity",
-                              "valueType": "xs:string",
-                              "value": "ZeroToOne"
-                            }
-                          ],
-                          "modelType": "MultiLanguageProperty"
-                        },
-                        {
-                          "idShort": "UnitList",
-                          "semanticId": {
-                            "type": "ExternalReference",
-                            "keys": [
-                              {
-                                "type": "GlobalReference",
-                                "value": "https://admin-shell.io/idta/SimulationModels/UnitList/1/0"
-                              }
-                            ]
-                          },
-                          "qualifiers": [
-                            {
-                              "kind": "ConceptQualifier",
-                              "type": "FormTitle",
-                              "valueType": "xs:string",
-                              "value": "unitList"
-                            },
-                            {
-                              "kind": "ConceptQualifier",
-                              "type": "FormInfo",
-                              "valueType": "xs:string",
-                              "value": "The most common units can be selected here. .. If \u0022others\u0022 is selected, a free text can be entered."
-                            },
-                            {
-                              "kind": "ConceptQualifier",
-                              "type": "PresetIdShort",
-                              "valueType": "xs:string",
-                              "value": "unitList"
-                            },
-                            {
-                              "kind": "ConceptQualifier",
-                              "type": "Multiplicity",
-                              "valueType": "xs:string",
-                              "value": "One"
-                            },
-                            {
-                              "kind": "ConceptQualifier",
-                              "type": "FormChoices",
-                              "valueType": "xs:string",
-                              "value": "s; m; kg; N; m/s; m/s^2; V; A; K; none"
-                            }
-                          ],
-                          "valueType": "xs:string",
-                          "modelType": "Property"
-                        },
-                        {
-                          "idShort": "UnitDescription",
-                          "semanticId": {
-                            "type": "ExternalReference",
-                            "keys": [
-                              {
-                                "type": "GlobalReference",
-                                "value": "https://admin-shell.io/idta/SimulationModels/UnitDescription/1/0"
-                              }
-                            ]
-                          },
-                          "qualifiers": [
-                            {
-                              "kind": "ConceptQualifier",
-                              "type": "FormTitle",
-                              "valueType": "xs:string",
-                              "value": "unitDescription"
-                            },
-                            {
-                              "kind": "ConceptQualifier",
-                              "type": "FormInfo",
-                              "valueType": "xs:string",
-                              "value": "Text field for missing units of the list."
-                            },
-                            {
-                              "kind": "ConceptQualifier",
-                              "type": "PresetIdShort",
-                              "valueType": "xs:string",
-                              "value": "unitDescription"
-                            },
-                            {
-                              "kind": "ConceptQualifier",
-                              "type": "Multiplicity",
-                              "valueType": "xs:string",
-                              "value": "ZeroToOne"
-                            }
-                          ],
-                          "modelType": "MultiLanguageProperty"
-                        },
-                        {
-                          "idShort": "VariableCausality",
-                          "semanticId": {
-                            "type": "ExternalReference",
-                            "keys": [
-                              {
-                                "type": "GlobalReference",
-                                "value": "https://admin-shell.io/idta/SimulationModels/VariableCausality/1/0"
-                              }
-                            ]
-                          },
-                          "qualifiers": [
-                            {
-                              "kind": "ConceptQualifier",
-                              "type": "FormTitle",
-                              "valueType": "xs:string",
-                              "value": "variableCausality"
-                            },
-                            {
-                              "kind": "ConceptQualifier",
-                              "type": "FormInfo",
-                              "valueType": "xs:string",
-                              "value": "The causality of the variable: input to inputs, output to ouputs, acausal connections (e.g. mechanical connection) do not have causality."
-                            },
-                            {
-                              "kind": "ConceptQualifier",
-                              "type": "PresetIdShort",
-                              "valueType": "xs:string",
-                              "value": "variableCausality"
-                            },
-                            {
-                              "kind": "ConceptQualifier",
-                              "type": "Multiplicity",
-                              "valueType": "xs:string",
-                              "value": "One"
-                            },
-                            {
-                              "kind": "ConceptQualifier",
-                              "type": "FormChoices",
-                              "valueType": "xs:string",
-                              "value": "input; output; acausal"
-                            }
-                          ],
-                          "valueType": "xs:string",
-                          "modelType": "Property"
-                        },
-                        {
-                          "idShort": "VariablePrefix",
-                          "semanticId": {
-                            "type": "ExternalReference",
-                            "keys": [
-                              {
-                                "type": "GlobalReference",
-                                "value": "https://admin-shell.io/idta/SimulationModels/VariablePrefix/1/0"
-                              }
-                            ]
-                          },
-                          "qualifiers": [
-                            {
-                              "kind": "ConceptQualifier",
-                              "type": "FormTitle",
-                              "valueType": "xs:string",
-                              "value": "variablePrefix"
-                            },
-                            {
-                              "kind": "ConceptQualifier",
-                              "type": "FormInfo",
-                              "valueType": "xs:string",
-                              "value": "Prefix for acausal variable. Potential variables are set equal when connecting (no prefix). Stream variables are connected according to Kirchhoff\u0027s law, i.e. the sum of the variables equals zero. The bi-directional flow of matter is described with \u0022stream\u0022 (e.g. for enthalpy)."
-                            },
-                            {
-                              "kind": "ConceptQualifier",
-                              "type": "PresetIdShort",
-                              "valueType": "xs:string",
-                              "value": "variablePrefix"
-                            },
-                            {
-                              "kind": "ConceptQualifier",
-                              "type": "Multiplicity",
-                              "valueType": "xs:string",
-                              "value": "ZeroToOne"
-                            },
-                            {
-                              "kind": "ConceptQualifier",
-                              "type": "FormChoices",
-                              "valueType": "xs:string",
-                              "value": "Flow; Stream"
-                            }
-                          ],
-                          "valueType": "xs:string",
-                          "modelType": "Property"
-                        }
-                      ],
-                      "modelType": "SubmodelElementCollection"
-                    }
-                  ],
-                  "modelType": "SubmodelElementCollection"
-                },
+                }
+            ]
+        },
+        {
+            "embeddedDataSpecifications": [
                 {
-                  "idShort": "BinaryConnector",
-                  "semanticId": {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "fax number"
+                            },
+                            {
+                                "language": "de",
+                                "text": "Faxnummer"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "complete telephone number to be called to reach a business partner's fax machine"
+                            },
+                            {
+                                "language": "de",
+                                "text": "vollst\u00e4ndige Telefonnummer, unter der das Faxger\u00e4t eines Gesch\u00e4ftspartners erreichbar ist"
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "FaxNum"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "TO_FIX",
+            "modelType": "ConceptDescription",
+            "id": "0173-1#02-AAO195#002",
+            "isCaseOf": [
+                {
                     "type": "ExternalReference",
                     "keys": [
-                      {
-                        "type": "GlobalReference",
-                        "value": "https://admin-shell.io/idta/SimulationModels/BinaryConnector/1/0"
-                      }
+                        {
+                            "type": "GlobalReference",
+                            "value": "0173-1#02-AAO195#002"
+                        }
                     ]
-                  },
-                  "qualifiers": [
-                    {
-                      "kind": "ConceptQualifier",
-                      "type": "FormTitle",
-                      "valueType": "xs:string",
-                      "value": "binaryConnector"
-                    },
-                    {
-                      "kind": "ConceptQualifier",
-                      "type": "FormInfo",
-                      "valueType": "xs:string",
-                      "value": "Binary interfaces (binaryType) based on the FMI 3.0 standard (https://fmi-standard.org/docs/3.0-dev/#definition-of-types). At this point the name (e.g. \u0022Binary interface visualization\u0022) and the description (e.g. \u0022Interface for binary transfer of visualization information\u0022) are specified."
-                    },
-                    {
-                      "kind": "ConceptQualifier",
-                      "type": "PresetIdShort",
-                      "valueType": "xs:string",
-                      "value": "binaryConnector\u0027{0:00}\u0027"
-                    },
-                    {
-                      "kind": "ConceptQualifier",
-                      "type": "Multiplicity",
-                      "valueType": "xs:string",
-                      "value": "ZeroToMany"
-                    }
-                  ],
-                  "value": [
-                    {
-                      "idShort": "BinaryConName",
-                      "semanticId": {
-                        "type": "ExternalReference",
-                        "keys": [
-                          {
-                            "type": "GlobalReference",
-                            "value": "https://admin-shell.io/idta/SimulationModels/BinaryConnectorName/1/0"
-                          }
-                        ]
-                      },
-                      "qualifiers": [
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "FormTitle",
-                          "valueType": "xs:string",
-                          "value": "binaryConName"
-                        },
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "FormInfo",
-                          "valueType": "xs:string",
-                          "value": "Binary interface name."
-                        },
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "PresetIdShort",
-                          "valueType": "xs:string",
-                          "value": "binConName"
-                        },
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "Multiplicity",
-                          "valueType": "xs:string",
-                          "value": "One"
-                        }
-                      ],
-                      "valueType": "xs:string",
-                      "modelType": "Property"
-                    },
-                    {
-                      "idShort": "BinaryConDescription",
-                      "semanticId": {
-                        "type": "ExternalReference",
-                        "keys": [
-                          {
-                            "type": "GlobalReference",
-                            "value": "https://admin-shell.io/idta/SimulationModels/BinaryConDescription/1/0"
-                          }
-                        ]
-                      },
-                      "qualifiers": [
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "FormTitle",
-                          "valueType": "xs:string",
-                          "value": "binaryConDescription"
-                        },
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "FormInfo",
-                          "valueType": "xs:string",
-                          "value": "Binary interface description."
-                        },
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "PresetIdShort",
-                          "valueType": "xs:string",
-                          "value": "binaryConDescription"
-                        },
-                        {
-                          "kind": "ConceptQualifier",
-                          "type": "Multiplicity",
-                          "valueType": "xs:string",
-                          "value": "ZeroToOne"
-                        }
-                      ],
-                      "modelType": "MultiLanguageProperty"
-                    }
-                  ],
-                  "modelType": "SubmodelElementCollection"
                 }
-              ],
-              "modelType": "SubmodelElementCollection"
-            }
-          ],
-          "modelType": "SubmodelElementCollection"
-        }
-      ],
-      "modelType": "Submodel"
-    }
-  ],
-  "conceptDescriptions": [
-    {
-      "idShort": "modelFile",
-      "id": "https://admin-shell.io/idta/SimulationModels/ModelFile/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "tbd"
-              },
-              {
-                "language": "de",
-                "text": "tbd"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "ModelFile"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "Providing versions of the simulation model and with characteristics to distinguish them."
-              },
-              {
-                "language": "de",
-                "text": "Bereitstellung von Versionen des Simulationsmodells und mit Merkmalen zur Unterscheidung."
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "modelFileComment",
-      "id": "https://admin-shell.io/sandbox/pi40/SimulationModel/modelFileComment/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "modelFileComment"
-              },
-              {
-                "language": "de",
-                "text": "modelFileComment"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "modelFileVersion",
-      "id": "https://admin-shell.io/idta/SimulationModels/ModelFileVersion/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "tbd"
-              },
-              {
-                "language": "de",
-                "text": "tbd"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "ModelFileVersion"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "Provision of a version of the simulation model with information to distinguish the versions. The versions are primarily intended for bug fixes without content changes."
-              },
-              {
-                "language": "de",
-                "text": "Bereitstellung einer Version des Simulationsmodells mit Informationen zur Unterscheidung der Versionen. Die Versionen sind in erster Linie f\u00FCr Fehlerbehebungen gedacht ohne inhaltliche \u00C4nderungen. "
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "modelFileReleaseNotesTxt",
-      "id": "https://admin-shell.io/idta/SimulationModels/ModelFileReleaseNotesTxt/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "tbd"
-              },
-              {
-                "language": "de",
-                "text": "tbd"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "contains information about this release"
-              },
-              {
-                "language": "de",
-                "text": "Informationen oder hinweise zu diesem Release"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "modelVersionId",
-      "id": "https://admin-shell.io/idta/SimulationModels/ModelVersionId/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "tbd"
-              },
-              {
-                "language": "de",
-                "text": "tbd"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "ModelVersionId"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "Version number of the model from the vendor."
-              },
-              {
-                "language": "de",
-                "text": "Versionnummer des Modells vom Herstellers."
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "digitalFile",
-      "id": "https://admin-shell.io/idta/SimulationModels/DigitalFile/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "tbd"
-              },
-              {
-                "language": "de",
-                "text": "tbd"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "DigitalFile"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "Deployment of the model file."
-              },
-              {
-                "language": "de",
-                "text": "Bereitstellung der Model-Datei."
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "modelPreviewImage",
-      "id": "https://admin-shell.io/idta/SimulationModels/ModelPreviewImage/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "tbd"
-              },
-              {
-                "language": "de",
-                "text": "tbd"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "ModelPreviewImage"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "Image file to represent the model in user interfaces, e.g. in a search."
-              },
-              {
-                "language": "de",
-                "text": "Bilddatei zur Repr\u00E4sentation des Modells in Oberfl\u00E4chen wie z.B. in einer Suche."
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "summary",
-      "id": "https://admin-shell.io/idta/SimulationModels/Summary/0/1",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "Content summary"
-              },
-              {
-                "language": "de",
-                "text": "Inhaltliche Zusammenfassung"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "Summary"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "Summary of the contents of the simulation model in text form. "
-              },
-              {
-                "language": "de",
-                "text": "Textliche Zusammenfassung des Inhalts des Simulationsmodells. "
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "paramMethod",
-      "id": "https://admin-shell.io/idta/SimulationModels/ParamMethod/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "tbd"
-              },
-              {
-                "language": "de",
-                "text": "tbd"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "ParamMethod"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "Indicates whether the model must be parameterized and if so, which method is required."
-              },
-              {
-                "language": "de",
-                "text": "Beschreibt, ob das Modell parametriert werden muss und wenn ja, welche Methode bereit gestellt wird."
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "paramFile",
-      "id": "https://admin-shell.io/idta/SimulationModels/ParamFile/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "tbd"
-              },
-              {
-                "language": "de",
-                "text": "tbd"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "ParamFile"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "File for parameterization of the model. As parameter file or parameter documentation (e.g. pdf). "
-              },
-              {
-                "language": "de",
-                "text": "Datei zur Parametrierung des Modells. Als Parameterdatei oder Parameterdokumentation (z.B. pdf). "
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "initStateMethod",
-      "id": "https://admin-shell.io/idta/SimulationModels/InitStateMethod/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "tbd"
-              },
-              {
-                "language": "de",
-                "text": "tbd"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "InitStateMethod"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "\u0022 Describes the state variables of the simulation model that must be initialized to start the simulation. For initial value problems, these quantities describe the system state at the start of the simulation. In this case, the system is in a state of equilibrium. Alternatively, a simulation model may include a method to determine consistent initial values at this step, e.g., at an operating point. "
-              },
-              {
-                "language": "de",
-                "text": "\u0022Beschreibt die Zustandgr\u00F6\u00DFen des Simulationsmodels, die zum Start der Simulation initialisiert werden m\u00FCssen. Bei Anfangswertproblemen beschreiben diese Gr\u00F6\u00DFen den Systemzustand zum Beginn der Simulation. Das System befindet sich dabei in einem Gleichgewichtszustand. Alternativ kann ein Simulationsmodell eine Methode beinhalten, die in diesem Schritt konsistente Anfangswerte z. B. in einem Betriebspunkt ermittelt. "
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "initStateFile",
-      "id": "https://admin-shell.io/idta/SimulationModels/InitStateFile/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "tbd"
-              },
-              {
-                "language": "de",
-                "text": "tbd"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "InitStateFile"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "File for parameterizing the initial states of the model. As parameter file or parameter documentation (e.g. pdf). "
-              },
-              {
-                "language": "de",
-                "text": "Datei zur Parametrierung der Anfangszust\u00E4nde des Modells. Als Parameterdatei oder Parameterdokumentation (z.B. pdf). "
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "refSimDocumentation",
-      "id": "https://admin-shell.io/idta/SimulationModels/RefSimDocumentation/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "Reference Simulation Documentation"
-              },
-              {
-                "language": "de",
-                "text": "Referenz Simulation Dokumentation"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "Documentation of example simulations of the model can be supplied. This includes a solver setup and sample circuit and sample results. e.g. zip file, PDF, html, ..."
-              },
-              {
-                "language": "de",
-                "text": "\u0022Es kann die Dokumentationen von Beispielsimulationen des Modells mitgeliefert werden. Dieses beinhaltet eine Solvereinstellung und eine Beispielbeschaltung und Beispielergebnisse. z.B. zip-Datei, PDF, html, \u2026"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "SimulationModel",
-      "id": "https://admin-shell.io/idta/SimulationModels/SimulationModel/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "SimulationModel"
-              },
-              {
-                "language": "de",
-                "text": "Simulationmodell"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "SimulationModel"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "licenseModel",
-      "id": "https://admin-shell.io/idta/SimulationModels/LicenseModel/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "tbd"
-              },
-              {
-                "language": "de",
-                "text": "tbd"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "LicenseModel"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "If a simulation model usage will be charged and how it will be charged."
-              },
-              {
-                "language": "de",
-                "text": "Ob und wie eine Nutzung des Simulationsmodells abgerechnet wird."
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "simModManufacturerInformation",
-      "id": "https://admin-shell.io/idta/SimulationModels/SimModManufacturerInformation/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "tbd"
-              },
-              {
-                "language": "de",
-                "text": "tbd"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "Provide access to  simulation support service provided by the distributor via mail or phone"
-              },
-              {
-                "language": "de",
-                "text": "Zugang zum Simulationssupport des Inverkehrbringers via Mail oder Telefon."
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "defaultSimTime",
-      "id": "https://admin-shell.io/idta/SimulationModels/DefaultSimTime/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "tbd"
-              },
-              {
-                "language": "de",
-                "text": "tbd"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "DefaultSimTime"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "Predefined simulation period in seconds "
-              },
-              {
-                "language": "de",
-                "text": "Voreingestellter Simulationszeitraum in Sekunden "
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "company",
-      "id": "0173-1#02-AAW001#001",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "tbd"
-              },
-              {
-                "language": "de",
-                "text": "tbd"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "Company"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "name of the company"
-              },
-              {
-                "language": "de",
-                "text": "Name des Unternehmens"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "language",
-      "id": "0173-1#02-AAO895#003",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "language"
-              },
-              {
-                "language": "de",
-                "text": "language"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "language"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "available language"
-              },
-              {
-                "language": "de",
-                "text": "verf\u00FCgbare Sprache"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "emailAddress",
-      "id": "0173-1#02-AAO198#002",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "tbd"
-              },
-              {
-                "language": "de",
-                "text": "tbd"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "EmailAddress"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "electronic mail address of a business partner"
-              },
-              {
-                "language": "de",
-                "text": "elektronische Postadresse eines Gesch\u00E4ftspartners"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "publicKey",
-      "id": "0173-1#02-AAO200#002",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "tbd"
-              },
-              {
-                "language": "de",
-                "text": "tbd"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "PublicKey"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "public part of an unsymmetrical key pair to sign or encrypt text or messages"
-              },
-              {
-                "language": "de",
-                "text": "\u00F6ffentlicher Teil eines unsymmetrischen Schl\u00FCsselpaares zum Signieren oder Verschl\u00FCsseln von Text oder Nachrichten"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "typeOfEmailAddress",
-      "id": "0173-1#02-AAO199#003",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "tbd"
-              },
-              {
-                "language": "de",
-                "text": "tbd"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "TypeOfEmailAddress"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "characterization of an e-mail address according to its location or usage"
-              },
-              {
-                "language": "de",
-                "text": "Charakterisierung einer E-Mail-Adresse nach ihrem Standort oder ihrer Verwendung"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "typeOfPublicKey",
-      "id": "0173-1#02-AAO201#002",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "tbd"
-              },
-              {
-                "language": "de",
-                "text": "tbd"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "TypeOfPublicKey"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "characterization of a public key according to its encryption process"
-              },
-              {
-                "language": "de",
-                "text": "Charakterisierung eines \u00F6ffentlichen Schl\u00FCssels nach seinem Verschl\u00FCsselungsverfahren"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "phone",
-      "id": "https://admin-shell.io/zvei/nameplate/1/0/ContactInformations/ContactInformation/Phone",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "tbd"
-              },
-              {
-                "language": "de",
-                "text": "tbd"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "Phone"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "Phone number including type"
-              },
-              {
-                "language": "de",
-                "text": "Rufnummer einschlie\u00DFlich Typ"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "typeOfTelephone",
-      "id": "0173-1#02-AAO137#003",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "tbd"
-              },
-              {
-                "language": "de",
-                "text": "tbd"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "TypeOfTelephone"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "characterization of a telephone according to its location or usage"
-              },
-              {
-                "language": "de",
-                "text": "Charakterisierung eines Telefons nach seinem Standort oder seiner Nutzung"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "availableTime",
-      "id": "https://admin-shell.io/zvei/nameplate/1/0/ContactInformations/ContactInformation/AvailableTime/",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "tbd"
-              },
-              {
-                "language": "de",
-                "text": "tbd"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "AvailableTime"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "Specification of the available time window"
-              },
-              {
-                "language": "de",
-                "text": "Spezifikation des verf\u00FCgbaren Zeitfensters"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "solverAndTolerances",
-      "id": "https://admin-shell.io/idta/SimulationModels/SolverAndTolerances/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "tbd"
-              },
-              {
-                "language": "de",
-                "text": "tbd"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "Useful settings of the simulation environment. Includes e.g. solver settings. "
-              },
-              {
-                "language": "de",
-                "text": "Sinnvolle Einstellungen der Simulationsumgebung. Beinhaltet z.B. Solvereinstellungen. "
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "stepSizeControlNeeded",
-      "id": "https://admin-shell.io/idta/SimulationModels/StepSizeControlNeeded/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "tbd"
-              },
-              {
-                "language": "de",
-                "text": "tbd"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "Solver with step size control recommended."
-              },
-              {
-                "language": "de",
-                "text": "Es wird eine Schrittweitensteuerung empfohlen."
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "fixedStepSize",
-      "id": "https://admin-shell.io/idta/SimulationModels/FixedStepSize/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "tbd"
-              },
-              {
-                "language": "de",
-                "text": "tbd"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "FixedStepSize"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "Fixed integration step size, if there is no adaptive step size "
-              },
-              {
-                "language": "de",
-                "text": "Feste Integrationsschrittweite, wenn keine Schritttweitensteuerung"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "tolerance",
-      "id": "https://admin-shell.io/idta/SimulationModels/Tolerance/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "tbd"
-              },
-              {
-                "language": "de",
-                "text": "tbd"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "Tolerance"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "(relative) tolerance for theadaptive step size "
-              },
-              {
-                "language": "de",
-                "text": "(relative) Toleranz f\u00FCr die Schrittweitensteuerung"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "solverIncluded",
-      "id": "https://admin-shell.io/idta/SimulationModels/SolverIncluded/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "tbd"
-              },
-              {
-                "language": "de",
-                "text": "tbd"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "SolverIncluded"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "Solver is integrated in the model (e.g. FMU for co-simulation)"
-              },
-              {
-                "language": "de",
-                "text": "Solver ist im Modell enthalten (z.B. FMU f\u00FCr Co-Simulation)"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "stiffSolverNeeded",
-      "id": "https://admin-shell.io/idta/SimulationModels/StiffSolverNeeded/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "tbd"
-              },
-              {
-                "language": "de",
-                "text": "tbd"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "StiffSolverNeeded"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "Stiff solver needed."
-              },
-              {
-                "language": "de",
-                "text": "Steifer Integrator erforderlich."
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "testedToolSolverAlgorithm",
-      "id": "https://admin-shell.io/idta/SimulationModels/TestedToolSolverAlgorithm/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "tbd"
-              },
-              {
-                "language": "de",
-                "text": "tbd"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "List of validated tool-solver combinations"
-              },
-              {
-                "language": "de",
-                "text": "Liste der getestete Tool-Solver Kombinationen"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "simTool",
-      "id": "https://admin-shell.io/sandbox/pi40/SimulationModel/simTool/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "simTool"
-              },
-              {
-                "language": "de",
-                "text": "simTool"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "solverAlgorithm",
-      "id": "https://admin-shell.io/idta/SimulationModels/SolverAlgorithm/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "tbd"
-              },
-              {
-                "language": "de",
-                "text": "tbd"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "SolverAlgorithm"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "validated solver"
-              },
-              {
-                "language": "de",
-                "text": "Getesteter Solver"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "toolSolverFurtherDescription",
-      "id": "https://admin-shell.io/idta/SimulationModels/ToolSolverFurtherDescription/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "tbd"
-              },
-              {
-                "language": "de",
-                "text": "tbd"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "Further tool- and solver-specific information"
-              },
-              {
-                "language": "de",
-                "text": "weitere Tool- und Solver-spezifischen Angaben"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "modelFileType",
-      "id": "https://admin-shell.io/idta/SimulationModels/ModelFileType/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "tbd"
-              },
-              {
-                "language": "de",
-                "text": "tbd"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "ModelFileType"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "\u0022Designation of the exchange format of the model. E.G.: FMI 1.0, Co-Simulation, Platform / Source - Code. FMI 2.0.2, Model Exchange, Source - Code, S-function, Version 2, 64bit, mex - Format / or C-Code, Modelica 3, encoded, VHDL"
-              },
-              {
-                "language": "de",
-                "text": "Bezeichnung des Austauschformates des Modells. Z.B.: FMI 1.0, Co-Simulation, Plattform / Source - Code FMI 2.0.2, Model Exchange, Source - Code, S-function, Version 2, 64bit, mex - Format / bzw. C-Code Modelica 3, verschl\u00FCsselt, VHDL"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "engineeringDomain",
-      "id": "https://admin-shell.io/idta/SimulationModels/EngineeringDomain/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "tbd"
-              },
-              {
-                "language": "de",
-                "text": "tbd"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "EngineeringDomain"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "List of engineering disciplines supported or mapped with the model. "
-              },
-              {
-                "language": "de",
-                "text": "Liste der technischen Fachgebiete die mit dem Modell unterst\u00FCtzt oder abbildet. "
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "engineeringDomainDesc",
-      "id": "https://admin-shell.io/sandbox/pi40/SimulationModel/engineeringDomainDesc/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "engineeringDomainDesc"
-              },
-              {
-                "language": "de",
-                "text": "engineeringDomainDesc"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "simPurpose",
-      "id": "https://admin-shell.io/idta/SimulationModels/SimPurpose/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "List of supportet und not supported simlulation purposes"
-              },
-              {
-                "language": "de",
-                "text": "Liste unterst\u00FCtzter und nicht unterst\u00FCtzter Simulationsziele"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "SimPurpose"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "This characteristic describes the simulation purpose or suitability for different simulation goals."
-              },
-              {
-                "language": "de",
-                "text": "Dieses Merkmal beschreibt den Simulationszweck oder die Eignung f\u00FCr verschiedene Simulationsziele."
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "posSimPurpose",
-      "id": "https://admin-shell.io/idta/SimulationModels/PosSimPurpose/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "Supported simulation purposes"
-              },
-              {
-                "language": "de",
-                "text": "Unterst\u00FCtzte Simulationsziele"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "PosSimPurpose"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "List of simulation purposes for which the model is intended."
-              },
-              {
-                "language": "de",
-                "text": "Liste der vom Simulationszwecke f\u00FCr die das Modell konzipiert ist."
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "negSimPurpose",
-      "id": "https://admin-shell.io/idta/SimulationModels/NegSimPurpose/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "Not supported simulation purposes"
-              },
-              {
-                "language": "de",
-                "text": "Ausgeschlossene Simulationsziele"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "NegSimPurpose"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "List of simulation purposes for which the model is explicitly not suitable. "
-              },
-              {
-                "language": "de",
-                "text": "Liste der Simulationszwecke f\u00FCr die das Modell explizit nicht geeignet ist. "
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "simPurDescription",
-      "id": "https://admin-shell.io/sandbox/pi40/SimulationModel/simPurDescription/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "simPurDescription"
-              },
-              {
-                "language": "de",
-                "text": "simPurDescription"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "scopeOfModel",
-      "id": "https://admin-shell.io/idta/SimulationModels/ScopeOfModel/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "tbd"
-              },
-              {
-                "language": "de",
-                "text": "tbd"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "ScopeOfModel"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "List of basic physical characteristics which are represented by the model."
-              },
-              {
-                "language": "de",
-                "text": "Liste an grunds\u00E4tzlichen pysikalischen Eigenschaften welche durch das Modell abgebildet werden."
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "scopeOfModelDesc",
-      "id": "https://admin-shell.io/sandbox/pi40/SimulationModel/scopeOfModelDesc/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "scopeOfModelDesc"
-              },
-              {
-                "language": "de",
-                "text": "scopeOfModelDesc"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "typeOfModelList",
-      "id": "https://admin-shell.io/sandbox/pi40/SimulationModel/typeOfModelList/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "typeOfModelList"
-              },
-              {
-                "language": "de",
-                "text": "typeOfModelList"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "typeOfModel",
-      "id": "https://admin-shell.io/idta/SimulationModels/TypeOfModel/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "tbd"
-              },
-              {
-                "language": "de",
-                "text": "tbd"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "TypeOfModel"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "List of modeling approaches used for the model."
-              },
-              {
-                "language": "de",
-                "text": "Liste der Modellierungsans\u00E4tze die f\u00FCr das Modell genutzt wurden."
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "environment",
-      "id": "https://admin-shell.io/idta/SimulationModels/Environment/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "tbd"
-              },
-              {
-                "language": "de",
-                "text": "tbd"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "Environment"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "Information about prerequisite environments or dependencies of underlying components on the target system."
-              },
-              {
-                "language": "de",
-                "text": "Informationen zu vorausgesetzten Umgebungen oder Abh\u00E4ngigkeiten umgebener Komponenten auf dem Zielsystem."
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "operatingSystem",
-      "id": "https://admin-shell.io/idta/SimulationModels/OperatingSystem/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "tbd"
-              },
-              {
-                "language": "de",
-                "text": "tbd"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "OperatingSystem"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "Name of the operating system including version and architecture (e.g. Windows 10 64bit)"
-              },
-              {
-                "language": "de",
-                "text": "Name des Betriebssystems inklusive Version und Architektur (z.B. Windows 10 64bit)"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "toolEnvironment",
-      "id": "https://admin-shell.io/idta/SimulationModels/ToolEnvironment/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "tbd"
-              },
-              {
-                "language": "de",
-                "text": "tbd"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "ToolEnvironment"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "List with required simulation tools, interpreters, model libraries or runtime libraries. In each case the exact designation of the software producer is given as free text."
-              },
-              {
-                "language": "de",
-                "text": "Liste mit vorrausgesetzten Simulationswerkzeugen, Interpreter, Modell-Bibliotheken oder Runtimebibliotheken. Es ist jeweils die genaue Bezeichung des Herstellers als Freitext angegeben."
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "dependency",
-      "id": "https://admin-shell.io/sandbox/pi40/SimulationModel/dependency/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "dependency"
-              },
-              {
-                "language": "de",
-                "text": "dependency"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "visualizationInformation",
-      "id": "https://admin-shell.io/idta/SimulationModels/VisualizationInformation/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "tbd"
-              },
-              {
-                "language": "de",
-                "text": "tbd"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "Ability to use a visualization. This can be integrated in a model or the model offers capabilities for connection. The connection can be described in more detail under Ports."
-              },
-              {
-                "language": "de",
-                "text": "\u0022M\u00F6glichkeit der Nutzung einer Visualisierung. Diese kann in einem Modell integriert sein oder das Modell bietet M\u00F6glichkeiten zur Anbindung. Die Anbindung kann unter Ports genauer beschrieben sein."
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "ports",
-      "id": "https://admin-shell.io/idta/SimulationModels/Ports/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "tbd"
-              },
-              {
-                "language": "de",
-                "text": "tbd"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "Ports"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "Interfaces of the model. This includes inputs, outputs as well as acausal connections (e.g. mechanical connections). In addition, it is specified here whether the model provides binary interfaces (e.g. for visualization)."
-              },
-              {
-                "language": "de",
-                "text": "Schnittstellen des Modells. Dies beinhaltet sowohl Eing\u00E4nge, Ausg\u00E4nge als auch akausale Verbindungen (z.B. mechanische Verbindungen). Zudem wird hier angegeben, ob das Modell bin\u00E4re Schnittstellen beinhaltet (z.B. f\u00FCr die Visualisierung)."
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "portsConnector",
-      "id": "https://admin-shell.io/idta/SimulationModels/PortsConnector/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "tbd"
-              },
-              {
-                "language": "de",
-                "text": "tbd"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "PortsConnector"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "List of ports of the model. These include a name, a description, a list of variables, and a list of ports."
-              },
-              {
-                "language": "de",
-                "text": "Liste der Ports des Modells. Diese beinhalten einen Namen, eine Beschreibung, eine Liste an Variablen sowie eine Liste an Ports."
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "portConName",
-      "id": "https://admin-shell.io/idta/SimulationModels/PortsConnectorName/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "tbd"
-              },
-              {
-                "language": "de",
-                "text": "tbd"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "PortConnectorName"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "Name of the Connector Port."
-              },
-              {
-                "language": "de",
-                "text": "Name des Port-Connectors."
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "portConDescription",
-      "id": "https://admin-shell.io/idta/SimulationModel/portConDescription/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "tbd"
-              },
-              {
-                "language": "de",
-                "text": "tbd"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "PortConDescription"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "Description of the Connector Port."
-              },
-              {
-                "language": "de",
-                "text": "Beschreibung des Port-Connectors."
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "variable",
-      "id": "https://admin-shell.io/idta/SimulationModels/Variable/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "tbd"
-              },
-              {
-                "language": "de",
-                "text": "tbd"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "Variable"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "List of variables of the port."
-              },
-              {
-                "language": "de",
-                "text": "Liste der Variablen des Ports."
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "variableName",
-      "id": "https://admin-shell.io/idta/SimulationModels/VariableName/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "tbd"
-              },
-              {
-                "language": "de",
-                "text": "tbd"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "VariableName"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "Name of the variable."
-              },
-              {
-                "language": "de",
-                "text": "Name der Variable."
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "variableDescription",
-      "id": "https://admin-shell.io/idta/SimulationModels/VariableDescription/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "tbd"
-              },
-              {
-                "language": "de",
-                "text": "tbd"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "Description of the variable."
-              },
-              {
-                "language": "de",
-                "text": "Beschreibung der Variable."
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "type",
-      "id": "https://admin-shell.io/idta/SimulationModels/VariableType/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "tbd"
-              },
-              {
-                "language": "de",
-                "text": "tbd"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "VariableType"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "Type of the variable (e.g. Real, Integer, Boolean, String or Enum)."
-              },
-              {
-                "language": "de",
-                "text": "Typ der Variable (z.B. Real, Integer, Boolean, String oder Enum)."
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "variableCausality",
-      "id": "https://admin-shell.io/idta/SimulationModels/VariableCausality/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "tbd"
-              },
-              {
-                "language": "de",
-                "text": "tbd"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "VariableCausality"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "The causality of the variable: input to inputs, output to ouputs, acausal connections (e.g. mechanical connection) do not have causality."
-              },
-              {
-                "language": "de",
-                "text": "Kausalit\u00E4t der Variable: input f\u00FCr Eing\u00E4nge, output f\u00FCr Ausg\u00E4nge, akausale Verbindungen (z.B. mechanische Verbindung) besitzen keine Kausalit\u00E4t."
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "variablePrefix",
-      "id": "https://admin-shell.io/idta/SimulationModels/VariablePrefix/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "tbd"
-              },
-              {
-                "language": "de",
-                "text": "tbd"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "VariablePrefix"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "Prefix for acausal variable. Potential variables are set equal when connecting (no prefix). Stream variables are connected according to Kirchhoff\u0027s law, i.e. the sum of the variables equals zero. The bi-directional flow of matter is described with \u0022stream\u0022 (e.g. for enthalpy)."
-              },
-              {
-                "language": "de",
-                "text": "Prefix f\u00FCr akausale Variable. Potentialvariablen werden beim Verbinden gleich gesetzt (kein Prefix). Flussvariablen werden nach Kirchhoffs Gesetz verbunden, d.h. die Summe der Variablen entspricht Null. Der bi-direktionale Fluss von Materie wird mit \u0022stream\u0022 beschrieben (z.B. f\u00FCr Enthalpie)."
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "unitList",
-      "id": "https://admin-shell.io/idta/SimulationModels/UnitList/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "tbd"
-              },
-              {
-                "language": "de",
-                "text": "tbd"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "UnitList"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "The most common units can be selected here. .. If \u0022others\u0022 is selected, a free text can be entered."
-              },
-              {
-                "language": "de",
-                "text": "Hier k\u00F6nnen die gebr\u00E4uchlichsten Einheiten ausgew\u00E4hlt werden. .. Bei Auswahl \u0022others\u0022 kann ein Freitext angegeben werden."
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "unitDescription",
-      "id": "https://admin-shell.io/idta/SimulationModels/UnitDescription/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "tbd"
-              },
-              {
-                "language": "de",
-                "text": "tbd"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "UnitDescription"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "Text field for missing units of the list"
-              },
-              {
-                "language": "de",
-                "text": "Freitext f\u00FCr fehlende Einheiten der Liste"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "range",
-      "id": "https://admin-shell.io/idta/SimulationModels/Range/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "tbd"
-              },
-              {
-                "language": "de",
-                "text": "tbd"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "Range"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "Range of values for the variable (e.g. [min, max], [min, max[, ]min, max], ]min, max[, {val1, val2, ...})."
-              },
-              {
-                "language": "de",
-                "text": "Wertebereich f\u00FCr die Variable (z.B. [min, max], [min, max[, ]min, max], ]min, max[, {val1, val2, ...})."
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "binaryConnector",
-      "id": "https://admin-shell.io/idta/SimulationModels/BinaryConnector/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "tbd"
-              },
-              {
-                "language": "de",
-                "text": "tbd"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "BinaryConnector"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "Binary interfaces (binaryType) based on the FMI 3.0 standard (https://fmi-standard.org/docs/3.0-dev/#definition-of-types). At this point the name (e.g. \u0022Binary interface visualization\u0022) and the description (e.g. \u0022Interface for binary transfer of visualization information\u0022) are specified."
-              },
-              {
-                "language": "de",
-                "text": "Bin\u00E4re Schnittstellen (binaryType) basierend auf dem FMI-3.0-Standard (https://fmi-standard.org/docs/3.0-dev/#definition-of-types). An dieser Stelle werden der Name (z.B. \u0022Bin\u00E4rschnittstelle Visualisierung\u0022) und die Beschreibung (z.B. \u0022Schnittstelle zum bin\u00E4ren \u00DCbertragen von Visualisierungsinformationen\u0022) angegeben."
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "binConName",
-      "id": "https://admin-shell.io/idta/SimulationModels/BinaryConnectorName/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "tbd"
-              },
-              {
-                "language": "de",
-                "text": "tbd"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "BinaryConName"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "Binary interface name."
-              },
-              {
-                "language": "de",
-                "text": "Name der bin\u00E4ren Schnittstelle."
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "binaryConDescription",
-      "id": "https://admin-shell.io/idta/SimulationModels/BinaryConDescription/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "tbd"
-              },
-              {
-                "language": "de",
-                "text": "tbd"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "Binary interface description."
-              },
-              {
-                "language": "de",
-                "text": "Beschreibung der bin\u00E4ren Schnittstelle."
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "modelFileReleaseNotesFile",
-      "id": "https://admin-shell.io/idta/SimulationModels/ModelFileReleaseNotesFile/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "tbd"
-              },
-              {
-                "language": "de",
-                "text": "tbd"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "release notes link or file"
-              },
-              {
-                "language": "de",
-                "text": "Datei oder Verkn\u00FCpfung zum Release Notes Dokument"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "dependencyEnvironment",
-      "id": "https://admin-shell.io/idta/SimulationModels/DependencyEnvironment/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "tbd"
-              },
-              {
-                "language": "de",
-                "text": "tbd"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "Description of dependencies to associated hardware and software. "
-              },
-              {
-                "language": "de",
-                "text": "Beschreibung von Abh\u00E4ngigkeiten zu umgebener Hardware und Software. "
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "simulationTool",
-      "id": "https://admin-shell.io/idta/SimulationModels/SimulationTool/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "tbd"
-              },
-              {
-                "language": "de",
-                "text": "tbd"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "SimulationTool"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "Properties of the model with regarding to concrete simulation tools"
-              },
-              {
-                "language": "de",
-                "text": "Eigenschaften des Modells bez\u00FCglich konkreter Simulationswerkzeuge."
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "simToolName",
-      "id": "https://admin-shell.io/idta/SimulationModels/SimToolName/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "simToolName"
-              },
-              {
-                "language": "de",
-                "text": "simToolName"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "simToolName"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "Name of the simulation tool including version."
-              },
-              {
-                "language": "de",
-                "text": "Name des Simulationtools inklusive Version"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "dependencySimTool",
-      "id": "https://admin-shell.io/idta/SimulationModels/DependencySimTool/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "tbd"
-              },
-              {
-                "language": "de",
-                "text": "tbd"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "DependencySimTool"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "Dependencies of Simulation Tools"
-              },
-              {
-                "language": "de",
-                "text": "Abh\u00E4ngigkeiten des Simulationtools"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "compiler",
-      "id": "https://admin-shell.io/idta/SimulationModels/Compiler/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "tbd"
-              },
-              {
-                "language": "de",
-                "text": "tbd"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "Compiler"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "Name of necessary compiler including version"
-              },
-              {
-                "language": "de",
-                "text": "Name des ben\u00F6tigten Comilers inklusive Version"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "id": "0173-1#02-AAO677#002",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "de",
-                "text": "Herstellername"
-              },
-              {
-                "language": "en",
-                "text": "Manufacturer name"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "ManNam"
-              }
-            ],
-            "definition": [
-              {
-                "language": "de",
-                "text": "Bezeichnung f\u00FCr eine nat\u00FCrliche oder juristische Person, die f\u00FCr die Auslegung, Herstellung und Verpackung sowie die Etikettierung eines Produkts im Hinblick auf das \u0027Inverkehrbringen\u0027 im eigenen Namen verantwortlich ist"
-              },
-              {
-                "language": "en",
-                "text": "legally valid designation of the natural or judicial person which is directly responsible for the design, production, packaging and labeling of a product in respect to its being brought into circulation"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "isCaseOf": [
-        {
-          "type": "ExternalReference",
-          "keys": [
-            {
-              "type": "GlobalReference",
-              "value": "0173-1#02-AAO677#002"
-            }
-          ]
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "id": "0173-1#02-AAW338#001",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "de",
-                "text": "Herstellerproduktbezeichnung"
-              },
-              {
-                "language": "en",
-                "text": "Manufacturer product designation"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "ManProDes"
-              }
-            ],
-            "definition": [
-              {
-                "language": "de",
-                "text": "Kurze Beschreibung des Produktes (Kurztext)"
-              },
-              {
-                "language": "en",
-                "text": "Short description of the product (short text)"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "isCaseOf": [
-        {
-          "type": "ExternalReference",
-          "keys": [
-            {
-              "type": "GlobalReference",
-              "value": "0173-1#02-AAW338#001"
-            }
-          ]
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "id": "0173-1#02-AAQ832#005",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "Address"
-              },
-              {
-                "language": "de",
-                "text": "Adresse"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "Add"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "Address information of a business partner"
-              },
-              {
-                "language": "de",
-                "text": "Adressinformationen zu einem Gesch\u00E4ftspartner"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "isCaseOf": [
-        {
-          "type": "ExternalReference",
-          "keys": [
-            {
-              "type": "GlobalReference",
-              "value": "0173-1#02-AAQ832#005"
-            }
-          ]
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "id": "0173-1#02-AAO127#003",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "de",
-                "text": "Abteilung"
-              },
-              {
-                "language": "en",
-                "text": "department"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "Dep"
-              }
-            ],
-            "definition": [
-              {
-                "language": "de",
-                "text": "administrative Abteilung einer Organisation, in der ein Gesch\u00E4ftspartner vertreten ist"
-              },
-              {
-                "language": "en",
-                "text": "administrative section within an organization where a business partner is located"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "isCaseOf": [
-        {
-          "type": "ExternalReference",
-          "keys": [
-            {
-              "type": "GlobalReference",
-              "value": "0173-1#02-AAO127#003"
-            }
-          ]
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "id": "0173-1#02-AAO128#002",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "street"
-              },
-              {
-                "language": "de",
-                "text": "Stra\u00DFe"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "Str"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "street name and house number"
-              },
-              {
-                "language": "de",
-                "text": "Stra\u00DFenname und Hausnummer"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "isCaseOf": [
-        {
-          "type": "ExternalReference",
-          "keys": [
-            {
-              "type": "GlobalReference",
-              "value": "0173-1#02-AAO128#002"
-            }
-          ]
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "id": "0173-1#02-AAO129#002",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "zip code"
-              },
-              {
-                "language": "de",
-                "text": "Postleitzahl"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "ZipCod"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "ZIP code of address"
-              },
-              {
-                "language": "de",
-                "text": "Postleitzahl der Anschrift"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "isCaseOf": [
-        {
-          "type": "ExternalReference",
-          "keys": [
-            {
-              "type": "GlobalReference",
-              "value": "0173-1#02-AAO129#002"
-            }
-          ]
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "id": "0173-1#02-AAO130#002",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "PO box"
-              },
-              {
-                "language": "de",
-                "text": "Postfach"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "POBox"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "P.O. box number"
-              },
-              {
-                "language": "de",
-                "text": "Nummer des Postfachs"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "isCaseOf": [
-        {
-          "type": "ExternalReference",
-          "keys": [
-            {
-              "type": "GlobalReference",
-              "value": "0173-1#02-AAO130#002"
-            }
-          ]
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "id": "0173-1#02-AAO131#002",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "zip code of PO box"
-              },
-              {
-                "language": "de",
-                "text": "Postleitzahl des Postfachs"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "ZipCodOfPOBox"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "ZIP code of P.O. box address"
-              },
-              {
-                "language": "de",
-                "text": "Postleitzahl der Postfachadresse"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "isCaseOf": [
-        {
-          "type": "ExternalReference",
-          "keys": [
-            {
-              "type": "GlobalReference",
-              "value": "0173-1#02-AAO131#002"
-            }
-          ]
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "id": "0173-1#02-AAO132#002",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "city/town"
-              },
-              {
-                "language": "de",
-                "text": "Ort"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "CitTow"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "town or city"
-              },
-              {
-                "language": "de",
-                "text": "Ortsangabe"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "isCaseOf": [
-        {
-          "type": "ExternalReference",
-          "keys": [
-            {
-              "type": "GlobalReference",
-              "value": "0173-1#02-AAO132#002"
-            }
-          ]
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "id": "0173-1#02-AAO133#002",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "state/county"
-              },
-              {
-                "language": "de",
-                "text": "Bundesland"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "StaCou"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "federal state a part of a state"
-              },
-              {
-                "language": "de",
-                "text": "Teil eines Bundesstaats"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "isCaseOf": [
-        {
-          "type": "ExternalReference",
-          "keys": [
-            {
-              "type": "GlobalReference",
-              "value": "0173-1#02-AAO133#002"
-            }
-          ]
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "id": "0173-1#02-AAO134#002",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "national code"
-              },
-              {
-                "language": "de",
-                "text": "L\u00E4ndercode"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "NatCod"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "code of a country"
-              },
-              {
-                "language": "de",
-                "text": "Code eines Landes"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "isCaseOf": [
-        {
-          "type": "ExternalReference",
-          "keys": [
-            {
-              "type": "GlobalReference",
-              "value": "0173-1#02-AAO134#002"
-            }
-          ]
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "id": "0173-1#02-AAO135#002",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "VAT number"
-              },
-              {
-                "language": "de",
-                "text": "Umsatzsteuer-ID"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "VATNum"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "VAT identification number of the business partner"
-              },
-              {
-                "language": "de",
-                "text": "Umsatzsteuer-ID des Gesch\u00E4ftspartners"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "isCaseOf": [
-        {
-          "type": "ExternalReference",
-          "keys": [
-            {
-              "type": "GlobalReference",
-              "value": "0173-1#02-AAO135#002"
-            }
-          ]
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "id": "0173-1#02-AAO202#003",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "address remarks"
-              },
-              {
-                "language": "de",
-                "text": "Anmerkungen zu Adresse"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "AddRem"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "plain text characterizing address information for which there is no property"
-              },
-              {
-                "language": "de",
-                "text": "einfacher Text, der Adressinformationen kennzeichnet, bei denen kein Merkmal zur Verf\u00FCgung steht"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "isCaseOf": [
-        {
-          "type": "ExternalReference",
-          "keys": [
-            {
-              "type": "GlobalReference",
-              "value": "0173-1#02-AAO202#003"
-            }
-          ]
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "id": "0173-1#02-AAQ326#002",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "address of additional link"
-              },
-              {
-                "language": "de",
-                "text": "zus\u00E4tzlicher Online-Verweis"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "AddOfAddLin"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "web site address where information about the product or contact is given"
-              },
-              {
-                "language": "de",
-                "text": "Angabe einer Web-Adresse, die zus\u00E4tzliche Informationen zum Produkt oder Kontaktdaten enth\u00E4lt"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "isCaseOf": [
-        {
-          "type": "ExternalReference",
-          "keys": [
-            {
-              "type": "GlobalReference",
-              "value": "0173-1#02-AAQ326#002"
-            }
-          ]
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "id": "0173-1#02-AAQ833#005",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "Phone"
-              },
-              {
-                "language": "de",
-                "text": "Telefon"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "Pho"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "Phone number including type"
-              },
-              {
-                "language": "de",
-                "text": "Telefonnummer mit Angabe der Art des Anschlusses"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "isCaseOf": [
-        {
-          "type": "ExternalReference",
-          "keys": [
-            {
-              "type": "GlobalReference",
-              "value": "0173-1#02-AAQ833#005"
-            }
-          ]
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "id": "0173-1#02-AAO136#002",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "telephone number"
-              },
-              {
-                "language": "de",
-                "text": "Telefonnummer"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "TelNum"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "complete telephone number to be called to reach a business partner"
-              },
-              {
-                "language": "de",
-                "text": "vollst\u00E4ndige Telefonnummer, unter der ein Gesch\u00E4ftspartner erreichbar ist"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "isCaseOf": [
-        {
-          "type": "ExternalReference",
-          "keys": [
-            {
-              "type": "GlobalReference",
-              "value": "0173-1#02-AAO136#002"
-            }
-          ]
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "id": "0173-1#02-AAQ834#005",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "Fax"
-              },
-              {
-                "language": "de",
-                "text": "Fax"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "Fax"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "Fax number including type"
-              },
-              {
-                "language": "de",
-                "text": "Faxnummer mit Angabe der Art des Anschlusses"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "isCaseOf": [
-        {
-          "type": "ExternalReference",
-          "keys": [
-            {
-              "type": "GlobalReference",
-              "value": "0173-1#02-AAQ834#005"
-            }
-          ]
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "id": "0173-1#02-AAO195#002",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "fax number"
-              },
-              {
-                "language": "de",
-                "text": "Faxnummer"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "FaxNum"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "complete telephone number to be called to reach a business partner\u0027s fax machine"
-              },
-              {
-                "language": "de",
-                "text": "vollst\u00E4ndige Telefonnummer, unter der das Faxger\u00E4t eines Gesch\u00E4ftspartners erreichbar ist"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "isCaseOf": [
-        {
-          "type": "ExternalReference",
-          "keys": [
-            {
-              "type": "GlobalReference",
-              "value": "0173-1#02-AAO195#002"
-            }
-          ]
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "id": "0173-1#02-AAO196#003",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "type of fax number"
-              },
-              {
-                "language": "de",
-                "text": "Art der Faxnummer"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "TypOfFaxNum"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "characterization of the fax according its location or usage"
-              },
-              {
-                "language": "de",
-                "text": "Charakterisierung des Fax bez\u00FCglich seines Orts oder Gebrauchs"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "isCaseOf": [
-        {
-          "type": "ExternalReference",
-          "keys": [
-            {
-              "type": "GlobalReference",
-              "value": "0173-1#02-AAO196#003"
-            }
-          ]
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "id": "0173-1#02-AAQ836#005",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "E-mail"
-              },
-              {
-                "language": "de",
-                "text": "E-Mail"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "Ema"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "E-mail address and encryption method"
-              },
-              {
-                "language": "de",
-                "text": "E-Mail-Adresse und Angaben zur Verschl\u00FCsselung"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "isCaseOf": [
-        {
-          "type": "ExternalReference",
-          "keys": [
-            {
-              "type": "GlobalReference",
-              "value": "0173-1#02-AAQ836#005"
-            }
-          ]
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "id": "0173-1#02-AAU731#001",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "de",
-                "text": "Herstellerproduktfamilie"
-              },
-              {
-                "language": "en",
-                "text": "Manufacturer product family"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "ManProFam"
-              }
-            ],
-            "definition": [
-              {
-                "language": "de",
-                "text": "2. Ebene einer 3 stufigen herstellerspezifischen Produkthierarchie"
-              },
-              {
-                "language": "en",
-                "text": "2nd level of a 3 level manufacturer specific product hierarchy"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "isCaseOf": [
-        {
-          "type": "ExternalReference",
-          "keys": [
-            {
-              "type": "GlobalReference",
-              "value": "0173-1#02-AAU731#001"
-            }
-          ]
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "id": "0173-1#02-AAM556#002",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "serial number"
-              },
-              {
-                "language": "de",
-                "text": "Seriennummer"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "SerNum"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "unique combination of numbers and letters used to identify the device once it has been manufactured"
-              },
-              {
-                "language": "de",
-                "text": "eindeutige Zahlen- und Buchstabenkombination, mit der das Ger\u00E4t nach seiner Herstellung identifiziert ist"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "isCaseOf": [
-        {
-          "type": "ExternalReference",
-          "keys": [
-            {
-              "type": "GlobalReference",
-              "value": "0173-1#02-AAM556#002"
-            }
-          ]
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "id": "0173-1#02-AAP906#001",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "de",
-                "text": "Baujahr"
-              },
-              {
-                "language": "en",
-                "text": "Year of construction"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "YeaOfCon"
-              }
-            ],
-            "definition": [
-              {
-                "language": "de",
-                "text": "Jahreszahl als Datumsangabe f\u00FCr die Fertigstellung des Objektes"
-              },
-              {
-                "language": "en",
-                "text": "Year as completion date of object"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "isCaseOf": [
-        {
-          "type": "ExternalReference",
-          "keys": [
-            {
-              "type": "GlobalReference",
-              "value": "0173-1#02-AAP906#001"
-            }
-          ]
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "id": "https://admin-shell.io/zvei/nameplate/1/0/Nameplate/Markings",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "Markings"
-              },
-              {
-                "language": "de",
-                "text": "Produktkennzeichnungen"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "Markings"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "Collection of product markings"
-              },
-              {
-                "language": "de",
-                "text": "Sammlung f\u00FCr Produktkennzeichnungen"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "id": "https://admin-shell.io/zvei/nameplate/1/0/Nameplate/Markings/Marking",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "Marking"
-              },
-              {
-                "language": "de",
-                "text": "Produktkennzeichnung"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "Marking"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "contains information about the marking labelled on the device"
-              },
-              {
-                "language": "de",
-                "text": "erfasst Information \u00FCber die Produktkennzeichnung"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "id": "https://admin-shell.io/zvei/nameplate/1/0/Nameplate/Markings/Marking/MarkingName",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "Marking name"
-              },
-              {
-                "language": "de",
-                "text": "Name der Produktkennzeichnung"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "MarkingName"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "common name of the marking"
-              },
-              {
-                "language": "de",
-                "text": "Markt\u00FCblicher Name der Produktkennzeichnung"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "id": "https://admin-shell.io/zvei/nameplate/1/0/Nameplate/Markings/Marking/MarkingFile",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "marking file"
-              },
-              {
-                "language": "de",
-                "text": "Datei der Produktkennzeichnung"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "MarkingFile"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "picture of the marking"
-              },
-              {
-                "language": "de",
-                "text": "Datei der Produktkennzeichnung"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "id": "https://admin-shell.io/zvei/nameplate/1/0/Nameplate/Markings/Marking/MarkingAdditionalText",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "marking additional text"
-              },
-              {
-                "language": "de",
-                "text": "Zusatztext der Produktkennzeichnung"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "where applicable, additional information on the marking in plain text"
-              },
-              {
-                "language": "de",
-                "text": "Zusatztext auf der Produktkennzeichnung als einfacher Text, falls verf\u00FCgbar"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "id": "https://admin-shell.io/zvei/nameplate/1/0/Nameplate/AssetSpecificProperties",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "Asset-specific properties"
-              },
-              {
-                "language": "de",
-                "text": "Asset-spezifische Merkmale"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "Collection of guideline-specific properties"
-              },
-              {
-                "language": "de",
-                "text": "Sammlung der Richtlinien-spezifischen Merkmale"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "id": "https://admin-shell.io/zvei/nameplate/1/0/Nameplate/AssetSpecificProperties/GuidelineSpecificProperties",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "Guideline-specific Properties"
-              },
-              {
-                "language": "de",
-                "text": "Richtlinie-spezifische Merkmale"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "Asset specific nameplate information required by guideline, stipulation or legislation"
-              },
-              {
-                "language": "de",
-                "text": "Asset-spezifische Typenschildinformation, die von weiteren Normen, Standards und Richtlinien gefordert wird"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "id": "0173-1#02-AAO856#002",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "guideline for conformity declaration"
-              },
-              {
-                "language": "de",
-                "text": "Richtlinie der Konformit\u00E4tserkl\u00E4rung"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "GuiForConDec"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "guideline, stipulation or legislation used for determining conformity"
-              },
-              {
-                "language": "de",
-                "text": "Richtlinie, Vorschrift oder des Gesetzes an Hand der die Konformit\u00E4t ermittelt wurde"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "isCaseOf": [
-        {
-          "type": "ExternalReference",
-          "keys": [
-            {
-              "type": "GlobalReference",
-              "value": "0173-1#02-AAO856#002"
-            }
-          ]
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "SimulationModel",
-      "id": "https://admin-shell.io/sandbox/SimulationModel/SimulationModel/1/1",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "SimulationModel"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "modelFile",
-      "id": "https://admin-shell.io/sandbox/SimulationModel/ModelFile/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "ModelFile"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "ModelFile"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "This property contains the access to the simulation model (file)."
-              },
-              {
-                "language": "de",
-                "text": "Dieses Merkmal enth\u00E4lt den Zugriff auf das Simulationsmodel (Datei). "
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "Comment",
-      "id": "https://admin-shell.io/vdi/2770/1/0/Comment",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "Comment"
-              }
-            ],
-            "sourceOfDefinition": "[ISO 15519-1:2010]",
-            "definition": [
-              {
-                "language": "de",
-                "text": "States a user-defined comment. Can be freely defined, even in multiple languages."
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "modelFileVersion",
-      "id": "https://admin-shell.io/vdi/2770/1/0/modelFileVersion",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "de",
-                "text": "Version des Dokuments"
-              },
-              {
-                "language": "en",
-                "text": "modelFileVersion"
-              }
-            ],
-            "definition": [
-              {
-                "language": "de",
-                "text": "Zu jedem Dokument muss eine Menge von mindestens einer Dokumentenversion existieren. Es k\u00F6nnen auch mehrere Dokumentenversionen ausgeliefert werden."
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "modelVersionIdValue",
-      "id": "https://admin-shell.io/vdi/2770/1/0/modelVersionId/Val",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "ModelVersionId"
-              }
-            ],
-            "definition": [
-              {
-                "language": "de",
-                "text": "Verschiedene Versionen eines Dokuments m\u00FCssen eindeutig identifizierbar sein. Die DocumentVersionId stellt eine innerhalb einer Dom\u00E4ne eindeutige Versionsidentifikationsnummer dar."
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "DigitalFile_00_",
-      "id": "https://admin-shell.io/vdi/2770/1/0/StoredDocumentRepresentation/DigitalFile",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "DigitalFile"
-              }
-            ],
-            "definition": [
-              {
-                "language": "de",
-                "text": "Eine Datei, die die DocumentVersion repr\u00E4sentiert. Neben der obligatorischen PDF/A Datei k\u00F6nnen weitere Dateien angegeben werden."
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "PreviewFile",
-      "id": "https://admin-shell.io/vdi/2770/1/0/StoredDocumentRepresentation/PreviewFile",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "DigitalFile"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "Provides a preview image of the Document, e.g. first page, in a commonly used image format and low resolution."
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "summary",
-      "id": "https://admin-shell.io/sandbox/SimulationModel/summary/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "summary"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "paramMethod",
-      "id": "https://admin-shell.io/sandbox/SimulationModel/paramMethod/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "paramMethod"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "paramFile",
-      "id": "https://admin-shell.io/sandbox/SimulationModel/paramFile/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "paramFile"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "initStateMethod",
-      "id": "https://admin-shell.io/sandbox/SimulationModel/initStateMethod/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "initStateMethod"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "Describes the states of the simulation model which have to be initialized at the start of the simulation. For initial value problems these values describes the state during the beginning of the simulation. Here, the system has a equibrilum state. Alternatively, a simulation model can contain a method, which determines consistent initial values. Another alternative would be to provide these values from a real system. For FMUs mantatory values are provided by the model_description-file, if the FMU does not contain solutions of a previous ismulation. Open Topic: units"
-              },
-              {
-                "language": "de",
-                "text": "Beschreibt die Zustandgr\u00F6\u00DFen des Simulationsmodels, die zum Start der Simulation initialisiert werden m\u00FCssen. Bei Anfangswertproblemen beschreiben diese Gr\u00F6\u00DFen den Systemzustand zum Beginn der Simulation. Das System beindet isch dabei in einem Gleichgewichtszustand. Alternativ kann ein Simulationsmodell eine Methode beinhalten, die in diesem Schritt konsistente Anfangswerte ermittelt. F\u00FCr FMU kann"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "initStateFile",
-      "id": "https://admin-shell.io/sandbox/SimulationModel/initStateFile/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "initStateFile"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "RefSimDocumentation",
-      "id": "https://admin-shell.io/sandbox/SimulationModel/RefSimDocumentation/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "RefSimDocumentation"
-              }
-            ],
-            "definition": [
-              {
-                "language": "de",
-                "text": "Es kann die Dokumentation einer Beispielsimulation des Modells mitgeliefert werden. Dieses beinhaltet eine Solvereinstellung und eine Beispielbeschaltung und Beispielergebnisse."
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "LicenceModel",
-      "id": "https://admin-shell.io/sandbox/SimulationModel/LicenceModel/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "LicenceModel"
-              }
-            ],
-            "definition": [
-              {
-                "language": "de",
-                "text": "Ob und wie eine Nutzung abgerechnet wird."
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "kindOfModel",
-      "id": "https://admin-shell.io/sandbox/SimulationModel/kindOfModel/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "kindOfModel"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "SimulationSupportContact",
-      "id": "https://admin-shell.io/sandbox/SimulationModel/SimulationSupportContact/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "SimulationSupportContact"
-              }
-            ],
-            "definition": [
-              {
-                "language": "de",
-                "text": "Zugang zu einem Simulationssupport des Inverkehrbringers. URL, Mail, Telefon"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "NameOfSupplier",
-      "administration": {},
-      "id": "0173-1#02-AAO735#003",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "name of supplier"
-              },
-              {
-                "language": "de",
-                "text": "Lieferantenname"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "name of supplier"
-              }
-            ],
-            "definition": [
-              {
-                "language": "de",
-                "text": "Name des Lieferanten, welcher dem Kunden ein Produkt oder eine Dienstleistung bereitstellt"
-              },
-              {
-                "language": "en",
-                "text": "name of supplier which provides the customer with a product or a service"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "CountryCode",
-      "administration": {},
-      "id": "0173-1#02-AAO730#001",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "de",
-                "text": "Landeskennung"
-              },
-              {
-                "language": "en",
-                "text": "Country code"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "Country code"
-              }
-            ],
-            "definition": [
-              {
-                "language": "de",
-                "text": "Vereinbartes Merkmal zur eindeutigen Identifizierung eines Landes"
-              },
-              {
-                "language": "en",
-                "text": "agreed upon symbol for unambiguous identification of a country"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "Street",
-      "id": "0173-1#02-AAO128#001",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "de",
-                "text": "Strasse"
-              },
-              {
-                "language": "en",
-                "text": "Street"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "Street"
-              }
-            ],
-            "definition": [
-              {
-                "language": "de",
-                "text": "Name der Strasse und Hausnummer"
-              },
-              {
-                "language": "en",
-                "text": "Street name and house number"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "CityTown",
-      "id": "0173-1#02-AAO132#001",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "de",
-                "text": "Ort"
-              },
-              {
-                "language": "en",
-                "text": "City/town"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "City/town"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "Town or city of the company"
-              },
-              {
-                "language": "de",
-                "text": "Ortsangabe"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "URL",
-      "id": "0173-1#02-AAO694#001",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "de",
-                "text": "Internetadresse"
-              },
-              {
-                "language": "en",
-                "text": "Internet address"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "URL"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "stated as link to a home page. The home page is the starting page or table of contents of a web site with offerings. It usually has the name index.htm or index.html"
-              },
-              {
-                "language": "de",
-                "text": "Angabe als Link, um in eine Homepage zu gelangen. die Homepage ist die Start- beziehungsweise die Inhaltsseite eines Web-Angebots. Meistens tr\u00E4gt sie den Namen index.htm oder index.html"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "engineeringDomain",
-      "id": "https://admin-shell.io/sandbox/SimulationModel/engineeringDomain/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "engineeringDomain"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "defaultSimTime",
-      "id": "https://admin-shell.io/sandbox/SimulationModel/defaultSimTime/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "defaultSimTime"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "SolverAndTolerances",
-      "id": "https://admin-shell.io/sandbox/SimulationModel/SolverAndTolerances/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "SolverAndTolerances"
-              }
-            ],
-            "definition": [
-              {
-                "language": "en",
-                "text": "Recommended simulation solver parameter"
-              },
-              {
-                "language": "de",
-                "text": "Sinnvolle Einstellungen der Simulationsumgebung."
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "stepSizeControlNeeded",
-      "id": "https://admin-shell.io/sandbox/SimulationModel/stepSizeControlNeeded/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "stepSizeControlNeeded"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "fixedStepSize",
-      "id": "https://admin-shell.io/sandbox/SimulationModel/fixedStepSize/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "fixedStepSize"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "tolerance",
-      "id": "https://admin-shell.io/sandbox/SimulationModel/tolerance/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "tolerance"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "solverIncluded",
-      "id": "https://admin-shell.io/sandbox/SimulationModel/solverIncluded/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "solverIncluded"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "stiffSolverNeeded",
-      "id": "https://admin-shell.io/sandbox/SimulationModel/stiffSolverNeeded/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "stiffSolverNeeded"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "testedToolSolverAlgorithm",
-      "id": "https://admin-shell.io/sandbox/SimulationModel/testedToolSolverAlgorithm/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "testedToolSolverAlgorithm"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "simTool",
-      "id": "https://admin-shell.io/sandbox/SimulationModel/simTool/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "simTool"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "solverAlgorithm",
-      "id": "https://admin-shell.io/sandbox/SimulationModel/solverAlgorithm/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "solverAlgorithm"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "toolSolverFurtherDescription",
-      "id": "https://admin-shell.io/sandbox/SimulationModel/toolSolverFurtherDescription/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "toolSolverFurtherDescription"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "simPurpose",
-      "id": "https://admin-shell.io/sandbox/SimulationModel/simPurpose/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "simPurpose"
-              }
-            ],
-            "definition": [
-              {
-                "language": "de",
-                "text": "Simulationszweck. Dieses Merkmal beschreibt die Eignung des Simulationsmodels f\u00FCr ein zugrundeliegendes Simulationsziel."
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "posSimPurpose",
-      "id": "https://admin-shell.io/sandbox/SimulationModel/posSimPurpose/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "posSimPurpose"
-              }
-            ],
-            "definition": [
-              {
-                "language": "de",
-                "text": "Vom Simulationsmodell unterst\u00FCtzte Simulationsziele "
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "negSimPurpose",
-      "id": "https://admin-shell.io/sandbox/SimulationModel/negSimPurpose/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "negSimPurpose"
-              }
-            ],
-            "definition": [
-              {
-                "language": "de",
-                "text": "Explizit ausgeschlossenen Simulationsziele, die das Simulationsmodell nicht unterst\u00FCtzt bzw. f\u00FCr das es nicht geeignet ist."
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "description",
-      "id": "https://admin-shell.io/sandbox/SimulationModel/description/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "description"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "environment",
-      "id": "https://admin-shell.io/sandbox/SimulationModel/environment/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "environment"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "OperatingSystem",
-      "id": "https://admin-shell.io/sandbox/SimulationModel/OperatingSystem/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "OperatingSystem"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "toolEnvironment",
-      "id": "https://admin-shell.io/sandbox/SimulationModel/toolEnvironment/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "toolEnvironment"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "dependency",
-      "id": "https://admin-shell.io/sandbox/SimulationModel/dependency/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "dependency"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "visualizationInformation",
-      "id": "https://admin-shell.io/sandbox/SimulationModel/visualizationInformation/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "visualizationInformation"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "ports",
-      "description": [
-        {
-          "language": "de",
-          "text": "hier sollten die Ein-Aufg\u00E4nge, phys. Anschl\u00FCsse beschrieben sein"
-        }
-      ],
-      "id": "https://admin-shell.io/sandbox/SimulationModel/ports/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "ports"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "port",
-      "id": "https://admin-shell.io/sandbox/SimulationModel/port/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "port"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "portName",
-      "id": "https://admin-shell.io/sandbox/SimulationModel/portName/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "portName"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "PortDescription",
-      "id": "https://admin-shell.io/sandbox/SimulationModel/PortDescription/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "PortDescription"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "portVariable",
-      "id": "https://admin-shell.io/sandbox/SimulationModel/portVariable/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "portVariable"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "PortVariableName",
-      "id": "https://admin-shell.io/sandbox/SimulationModel/PortVariableName/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "PortVariableName"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "PortVariableDescription",
-      "id": "https://admin-shell.io/sandbox/SimulationModel/PortVariableDescription/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "PortVariableDescription"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "PortVariableType",
-      "id": "https://admin-shell.io/sandbox/SimulationModel/PortVariableType/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "PortVariableType"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "PortVariableCausality",
-      "id": "https://admin-shell.io/sandbox/SimulationModel/PortVariableCausality/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "PortVariableCausality"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "PortVariablePrefix",
-      "id": "https://admin-shell.io/sandbox/SimulationModel/PortVariablePrefix/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "PortVariablePrefix"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "PortVariableUnit",
-      "id": "https://admin-shell.io/sandbox/SimulationModel/PortVariableUnit/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "PortVariableUnit"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "PortVariableRange",
-      "id": "https://admin-shell.io/sandbox/SimulationModel/PortVariableRange/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "PortVariableRange"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "BinaryName",
-      "id": "https://admin-shell.io/sandbox/SimulationModel/BinaryName/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "BinaryName"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "BinaryDescription",
-      "id": "https://admin-shell.io/sandbox/SimulationModel/BinaryDescription/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "BinaryDescription"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "SimulationModel",
-      "id": "https://admin-shell.io/sandbox/SimulationModel/SimulationModel/0/1",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "SimulationModel"
-              },
-              {
-                "language": "de",
-                "text": "SimulationModel"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "summary",
-      "id": "\u0022https://admin-shell.io/sandbox/pi40/SimulationModel/Summary/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "summary"
-              },
-              {
-                "language": "de",
-                "text": "summary"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "simPurpose",
-      "id": "https://admin-shell.io/sandbox/pi40/SimulationModel/simPurpose/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "simPurpose"
-              },
-              {
-                "language": "de",
-                "text": "simPurpose"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "posSimPurpose",
-      "id": "https://admin-shell.io/sandbox/pi40/SimulationModel/posSimPurpose/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "posSimPurpose"
-              },
-              {
-                "language": "de",
-                "text": "posSimPurpose"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "negSimPurpose",
-      "id": "https://admin-shell.io/sandbox/pi40/SimulationModel/negSimPurpose/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "negSimPurpose"
-              },
-              {
-                "language": "de",
-                "text": "negSimPurpose"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "typeOfModel",
-      "id": "https://admin-shell.io/sandbox/pi40/SimulationModel/typeOfModel/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
             ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "typeOfModel"
-              },
-              {
-                "language": "de",
-                "text": "typeOfModel"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "scopeOfModel",
-      "id": "https://admin-shell.io/sandbox/pi40/SimulationModel/scopeOfModel/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "scopeOfModel"
-              },
-              {
-                "language": "de",
-                "text": "scopeOfModel"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "licenseModel",
-      "id": "https://admin-shell.io/sandbox/pi40/SimulationModel/licenseModel/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "licenseModel"
-              },
-              {
-                "language": "de",
-                "text": "licenseModel"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "engineeringDomain",
-      "id": "https://admin-shell.io/sandbox/pi40/SimulationModel/engineeringDomainList/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "engineeringDomain"
-              },
-              {
-                "language": "de",
-                "text": "engineeringDomain"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "environment",
-      "id": "https://admin-shell.io/sandbox/pi40/SimulationModel/environment/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "environment"
-              },
-              {
-                "language": "de",
-                "text": "environment"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "operatingSystem",
-      "id": "https://admin-shell.io/sandbox/pi40/SimulationModel/operatingSystem/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "operatingSystem"
-              },
-              {
-                "language": "de",
-                "text": "operatingSystem"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "toolEnvironment",
-      "id": "https://admin-shell.io/sandbox/pi40/SimulationModel/toolEnvironment/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "toolEnvironment"
-              },
-              {
-                "language": "de",
-                "text": "toolEnvironment"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "dependencyEnvironment",
-      "id": "https://admin-shell.io/sandbox/pi40/SimulationModel/dependencyEnvironment/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "dependencyEnvironment"
-              },
-              {
-                "language": "de",
-                "text": "dependencyEnvironment"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "visualizationInformation",
-      "id": "https://admin-shell.io/sandbox/pi40/SimulationModel/visualizationInformation/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "visualizationInformation"
-              },
-              {
-                "language": "de",
-                "text": "visualizationInformation"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "simulationTool",
-      "id": "https://admin-shell.io/sandbox/pi40/SimulationModel/simulationTool/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "simulationTool"
-              },
-              {
-                "language": "de",
-                "text": "simulationTool"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "SimToolName",
-      "id": "https://admin-shell.io/idta/SimulationModel/SimToolName/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "tbd"
-              },
-              {
-                "language": "de",
-                "text": "tbd"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "dependencySimTool",
-      "id": "https://admin-shell.io/sandbox/pi40/SimulationModel/dependencySimTool/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "dependencySimTool"
-              },
-              {
-                "language": "de",
-                "text": "dependencySimTool"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "compiler",
-      "id": "https://admin-shell.io/sandbox/pi40/SimulationModel/compiler/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "compiler"
-              },
-              {
-                "language": "de",
-                "text": "compiler"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "solverAndTolerances",
-      "id": "https://admin-shell.io/sandbox/pi40/SimulationModel/solverAndTolerances/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "solverAndTolerances"
-              },
-              {
-                "language": "de",
-                "text": "solverAndTolerances"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "stepSizeControlNeeded",
-      "id": "https://admin-shell.io/sandbox/pi40/SimulationModel/stepSizeControlNeeded/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "stepSizeControlNeeded"
-              },
-              {
-                "language": "de",
-                "text": "stepSizeControlNeeded"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "fixedStepSize",
-      "id": "https://admin-shell.io/sandbox/pi40/SimulationModel/fixedStepSize/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "fixedStepSize"
-              },
-              {
-                "language": "de",
-                "text": "fixedStepSize"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "stiffSolverNeeded",
-      "id": "https://admin-shell.io/sandbox/pi40/SimulationModel/stiffSolverNeeded/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "stiffSolverNeeded"
-              },
-              {
-                "language": "de",
-                "text": "stiffSolverNeeded"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "solverIncluded",
-      "id": "https://admin-shell.io/sandbox/pi40/SimulationModel/solverIncluded/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "solverIncluded"
-              },
-              {
-                "language": "de",
-                "text": "solverIncluded"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "testedToolSolverAlgorithm",
-      "id": "https://admin-shell.io/sandbox/pi40/SimulationModel/testedToolSolverAlgorithm/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "testedToolSolverAlgorithm"
-              },
-              {
-                "language": "de",
-                "text": "testedToolSolverAlgorithm"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "solverAlgorithm",
-      "id": "https://admin-shell.io/sandbox/pi40/SimulationModel/solverAlgorithm/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "solverAlgorithm"
-              },
-              {
-                "language": "de",
-                "text": "solverAlgorithm"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "toolSolverFurtherDescription",
-      "id": "https://admin-shell.io/sandbox/pi40/SimulationModel/toolSolverFurtherDescription/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "toolSolverFurtherDescription"
-              },
-              {
-                "language": "de",
-                "text": "toolSolverFurtherDescription"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "tolerance",
-      "id": "https://admin-shell.io/sandbox/pi40/SimulationModel/tolerance/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "tolerance"
-              },
-              {
-                "language": "de",
-                "text": "tolerance"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "refSimDocumentation",
-      "id": "https://example.com/ids/cd/2065_0120_2022_9178",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "Reference Simulation Documentation"
-              },
-              {
-                "language": "de",
-                "text": "Referenz Simulation Dokumentation"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "refSimDoc"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "modelFile",
-      "id": "https://admin-shell.io/sandbox/pi40/SimulationModel/modelFile/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "modelFile"
-              },
-              {
-                "language": "de",
-                "text": "modelFile"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "modelFile"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "modelFileType",
-      "id": "https://admin-shell.io/sandbox/pi40/SimulationModel/modelFileType/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "modelFileType"
-              },
-              {
-                "language": "de",
-                "text": "modelFileType"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "modelFileVersion",
-      "id": "https://admin-shell.io/sandbox/pi40/SimulationModel/modelFileVersion/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "modelFileVersion"
-              },
-              {
-                "language": "de",
-                "text": "modelFileVersion"
-              }
-            ],
-            "shortName": [
-              {
-                "language": "en",
-                "text": "modelFileVersion"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "modelVersionId",
-      "id": "https://admin-shell.io/sandbox/pi40/SimulationModel/ModelVersionId/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "modelVersionId"
-              },
-              {
-                "language": "de",
-                "text": "modelVersionId"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "modelPreviewImage",
-      "id": "https://admin-shell.io/sandbox/pi40/SimulationModel/modelPreviewImage/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "modelPreviewImage"
-              },
-              {
-                "language": "de",
-                "text": "modelPreviewImage"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "digitalFile",
-      "id": "https://admin-shell.io/sandbox/pi40/SimulationModel/digitalFile/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "digitalFile"
-              },
-              {
-                "language": "de",
-                "text": "digitalFile"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "modelFileReleaseNotesTxt",
-      "id": "https://admin-shell.io/sandbox/pi40/SimulationModel/modelFileReleaseNotesTxt/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "modelFileReleaseNotesTxt"
-              },
-              {
-                "language": "de",
-                "text": "modelFileReleaseNotesTxt"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "modelFileReleaseNotesFile",
-      "id": "https://admin-shell.io/sandbox/pi40/SimulationModel/modelFileReleaseNotesFile/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "modelFileReleaseNotesFile"
-              },
-              {
-                "language": "de",
-                "text": "modelFileReleaseNotesFile"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "paramMethod",
-      "id": "https://admin-shell.io/sandbox/pi40/SimulationModel/paramMethod/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "paramMethod"
-              },
-              {
-                "language": "de",
-                "text": "paramMethod"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "paramFile",
-      "id": "https://admin-shell.io/sandbox/pi40/SimulationModel/paramFile/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "paramFile"
-              },
-              {
-                "language": "de",
-                "text": "paramFile"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "initStateMethod",
-      "id": "https://admin-shell.io/sandbox/pi40/SimulationModel/initStateMethod/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "initStateMethod"
-              },
-              {
-                "language": "de",
-                "text": "initStateMethod"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "initStateFile",
-      "id": "https://admin-shell.io/sandbox/pi40/SimulationModel/initStateFile/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "initStateFile"
-              },
-              {
-                "language": "de",
-                "text": "initStateFile"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "defaultSimTime",
-      "id": "https://admin-shell.io/sandbox/pi40/SimulationModel/defaultSimTime/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "defaultSimTime"
-              },
-              {
-                "language": "de",
-                "text": "defaultSimTime"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "simModManufacturerInformation",
-      "id": "https://admin-shell.io/sandbox/pi40/SimulationModel/SimModManufacturerInformation/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "simModManufacturerInformation"
-              },
-              {
-                "language": "de",
-                "text": "simModManufacturerInformation"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "ports",
-      "id": "https://admin-shell.io/sandbox/pi40/SimulationModel/ports/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "ports"
-              },
-              {
-                "language": "de",
-                "text": "ports"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "portsConnector",
-      "id": "https://admin-shell.io/sandbox/pi40/SimulationModel/portsConnector/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "portsConnector"
-              },
-              {
-                "language": "de",
-                "text": "portsConnector"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "portConName",
-      "id": "https://admin-shell.io/sandbox/pi40/SimulationModel/portConnectorName/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "portConnectorName"
-              },
-              {
-                "language": "de",
-                "text": "portConnectorName"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "portConDescription",
-      "id": "https://admin-shell.io/sandbox/pi40/SimulationModel/portConDescription/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "portConDescription"
-              },
-              {
-                "language": "de",
-                "text": "portConDescription"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "variable",
-      "id": "https://admin-shell.io/sandbox/pi40/SimulationModel/variable/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "variable"
-              },
-              {
-                "language": "de",
-                "text": "variable"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "variableName",
-      "id": "https://admin-shell.io/sandbox/pi40/SimulationModel/variableName/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "variableName"
-              },
-              {
-                "language": "de",
-                "text": "variableName"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "range",
-      "id": "https://admin-shell.io/sandbox/pi40/SimulationModel/range/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "range"
-              },
-              {
-                "language": "de",
-                "text": "range"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "type",
-      "id": "https://admin-shell.io/sandbox/pi40/SimulationModel/variableType/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "variableType"
-              },
-              {
-                "language": "de",
-                "text": "variableType"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "variableDescription",
-      "id": "https://admin-shell.io/sandbox/pi40/SimulationModel/variableDescription/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "variableDescription"
-              },
-              {
-                "language": "de",
-                "text": "variableDescription"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "unitList",
-      "id": "https://admin-shell.io/sandbox/pi40/SimulationModel/unitList/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "unitList"
-              },
-              {
-                "language": "de",
-                "text": "unitList"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "unitDescription",
-      "id": "https://admin-shell.io/sandbox/pi40/SimulationModel/unitDescription/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "unitDescription"
-              },
-              {
-                "language": "de",
-                "text": "unitDescription"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "variableCausality",
-      "id": "https://admin-shell.io/sandbox/pi40/SimulationModel/variableCausality/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "variableCausality"
-              },
-              {
-                "language": "de",
-                "text": "variableCausality"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "variablePrefix",
-      "id": "https://admin-shell.io/sandbox/pi40/SimulationModel/variablePrefix/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "variablePrefix"
-              },
-              {
-                "language": "de",
-                "text": "variablePrefix"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "binaryConnector",
-      "id": "https://admin-shell.io/sandbox/pi40/SimulationModel/binaryConnector/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "binaryConnector"
-              },
-              {
-                "language": "de",
-                "text": "binaryConnector"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "binConName",
-      "id": "https://admin-shell.io/sandbox/pi40/SimulationModel/binConName/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "binConName"
-              },
-              {
-                "language": "de",
-                "text": "binConName"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "binaryConDescription",
-      "id": "https://admin-shell.io/sandbox/pi40/SimulationModel/binaryConDescription/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "binaryConDescription"
-              },
-              {
-                "language": "de",
-                "text": "binaryConDescription"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "company",
-      "id": "https://admin-shell.io/sandbox/pi40/SimulationModel/company/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "company"
-              },
-              {
-                "language": "de",
-                "text": "company"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "language",
-      "id": "https://admin-shell.io/sandbox/pi40/SimulationModel/language/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "language"
-              },
-              {
-                "language": "de",
-                "text": "language"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "email",
-      "id": "https://admin-shell.io/sandbox/pi40/SimulationModel/email/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "email"
-              },
-              {
-                "language": "de",
-                "text": "email"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "typeOfEmailAddress",
-      "id": "https://admin-shell.io/sandbox/pi40/SimulationModel/typeOfEmailAddress/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "typeOfEmailAddress"
-              },
-              {
-                "language": "de",
-                "text": "typeOfEmailAddress"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "emailAddress",
-      "id": "https://admin-shell.io/sandbox/pi40/SimulationModel/emailAddress/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "emailAddress"
-              },
-              {
-                "language": "de",
-                "text": "emailAddress"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "typeOfPublicKey",
-      "id": "https://admin-shell.io/sandbox/pi40/SimulationModel/typeOfPublickKey/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "typeOfPublicKey"
-              },
-              {
-                "language": "de",
-                "text": "typeOfPublicKey"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "publicKey",
-      "id": "https://admin-shell.io/sandbox/pi40/SimulationModel/publicKey/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "publicKey"
-              },
-              {
-                "language": "de",
-                "text": "publicKey"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "phone",
-      "id": "https://admin-shell.io/sandbox/pi40/SimulationModel/phone/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "phone"
-              },
-              {
-                "language": "de",
-                "text": "phone"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "typeOfTelephone",
-      "id": "https://admin-shell.io/sandbox/pi40/SimulationModel/typOfTelephone/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "typeOfTelephone"
-              },
-              {
-                "language": "de",
-                "text": "typeOfTelephone"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "telephoneNumber",
-      "id": "https://admin-shell.io/sandbox/pi40/SimulationModel/telephoneNumber/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "telephoneNumber"
-              },
-              {
-                "language": "de",
-                "text": "telephoneNumber"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    },
-    {
-      "idShort": "availableTime",
-      "id": "https://admin-shell.io/sandbox/pi40/SimulationModel/availableTime/1/0",
-      "embeddedDataSpecifications": [
-        {
-          "dataSpecification": {
-            "type": "ExternalReference",
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
-              }
-            ]
-          },
-          "dataSpecificationContent": {
-            "preferredName": [
-              {
-                "language": "en",
-                "text": "availableTime"
-              },
-              {
-                "language": "de",
-                "text": "availableTime"
-              }
-            ],
-            "modelType": "DataSpecificationIec61360"
-          }
-        }
-      ],
-      "modelType": "ConceptDescription"
-    }
-  ]
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "type of fax number"
+                            },
+                            {
+                                "language": "de",
+                                "text": "Art der Faxnummer"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "characterization of the fax according its location or usage"
+                            },
+                            {
+                                "language": "de",
+                                "text": "Charakterisierung des Fax bez\u00fcglich seines Orts oder Gebrauchs"
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "TypOfFaxNum"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "TO_FIX",
+            "modelType": "ConceptDescription",
+            "id": "0173-1#02-AAO196#003",
+            "isCaseOf": [
+                {
+                    "type": "ExternalReference",
+                    "keys": [
+                        {
+                            "type": "GlobalReference",
+                            "value": "0173-1#02-AAO196#003"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "E-mail"
+                            },
+                            {
+                                "language": "de",
+                                "text": "E-Mail"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "E-mail address and encryption method"
+                            },
+                            {
+                                "language": "de",
+                                "text": "E-Mail-Adresse und Angaben zur Verschl\u00fcsselung"
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "Ema"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "TO_FIX",
+            "modelType": "ConceptDescription",
+            "id": "0173-1#02-AAQ836#005",
+            "isCaseOf": [
+                {
+                    "type": "ExternalReference",
+                    "keys": [
+                        {
+                            "type": "GlobalReference",
+                            "value": "0173-1#02-AAQ836#005"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "de",
+                                "text": "Herstellerproduktfamilie"
+                            },
+                            {
+                                "language": "en",
+                                "text": "Manufacturer product family"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "de",
+                                "text": "2. Ebene einer 3 stufigen herstellerspezifischen Produkthierarchie"
+                            },
+                            {
+                                "language": "en",
+                                "text": "2nd level of a 3 level manufacturer specific product hierarchy"
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "ManProFam"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "TO_FIX",
+            "modelType": "ConceptDescription",
+            "id": "0173-1#02-AAU731#001",
+            "isCaseOf": [
+                {
+                    "type": "ExternalReference",
+                    "keys": [
+                        {
+                            "type": "GlobalReference",
+                            "value": "0173-1#02-AAU731#001"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "serial number"
+                            },
+                            {
+                                "language": "de",
+                                "text": "Seriennummer"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "unique combination of numbers and letters used to identify the device once it has been manufactured"
+                            },
+                            {
+                                "language": "de",
+                                "text": "eindeutige Zahlen- und Buchstabenkombination, mit der das Ger\u00e4t nach seiner Herstellung identifiziert ist"
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "SerNum"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "TO_FIX",
+            "modelType": "ConceptDescription",
+            "id": "0173-1#02-AAM556#002",
+            "isCaseOf": [
+                {
+                    "type": "ExternalReference",
+                    "keys": [
+                        {
+                            "type": "GlobalReference",
+                            "value": "0173-1#02-AAM556#002"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "de",
+                                "text": "Baujahr"
+                            },
+                            {
+                                "language": "en",
+                                "text": "Year of construction"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "de",
+                                "text": "Jahreszahl als Datumsangabe f\u00fcr die Fertigstellung des Objektes"
+                            },
+                            {
+                                "language": "en",
+                                "text": "Year as completion date of object"
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "YeaOfCon"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "TO_FIX",
+            "modelType": "ConceptDescription",
+            "id": "0173-1#02-AAP906#001",
+            "isCaseOf": [
+                {
+                    "type": "ExternalReference",
+                    "keys": [
+                        {
+                            "type": "GlobalReference",
+                            "value": "0173-1#02-AAP906#001"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "Markings"
+                            },
+                            {
+                                "language": "de",
+                                "text": "Produktkennzeichnungen"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "Collection of product markings"
+                            },
+                            {
+                                "language": "de",
+                                "text": "Sammlung f\u00fcr Produktkennzeichnungen"
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "Markings"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "TO_FIX",
+            "modelType": "ConceptDescription",
+            "id": "https://admin-shell.io/zvei/nameplate/1/0/Nameplate/Markings"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "Marking"
+                            },
+                            {
+                                "language": "de",
+                                "text": "Produktkennzeichnung"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "contains information about the marking labelled on the device"
+                            },
+                            {
+                                "language": "de",
+                                "text": "erfasst Information \u00fcber die Produktkennzeichnung"
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "Marking"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "TO_FIX",
+            "modelType": "ConceptDescription",
+            "id": "https://admin-shell.io/zvei/nameplate/1/0/Nameplate/Markings/Marking"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "Marking name"
+                            },
+                            {
+                                "language": "de",
+                                "text": "Name der Produktkennzeichnung"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "common name of the marking"
+                            },
+                            {
+                                "language": "de",
+                                "text": "Markt\u00fcblicher Name der Produktkennzeichnung"
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "MarkingName"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "TO_FIX",
+            "modelType": "ConceptDescription",
+            "id": "https://admin-shell.io/zvei/nameplate/1/0/Nameplate/Markings/Marking/MarkingName"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "marking file"
+                            },
+                            {
+                                "language": "de",
+                                "text": "Datei der Produktkennzeichnung"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "picture of the marking"
+                            },
+                            {
+                                "language": "de",
+                                "text": "Datei der Produktkennzeichnung"
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "MarkingFile"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "TO_FIX",
+            "modelType": "ConceptDescription",
+            "id": "https://admin-shell.io/zvei/nameplate/1/0/Nameplate/Markings/Marking/MarkingFile"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "marking additional text"
+                            },
+                            {
+                                "language": "de",
+                                "text": "Zusatztext der Produktkennzeichnung"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "where applicable, additional information on the marking in plain text"
+                            },
+                            {
+                                "language": "de",
+                                "text": "Zusatztext auf der Produktkennzeichnung als einfacher Text, falls verf\u00fcgbar"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "TO_FIX",
+            "modelType": "ConceptDescription",
+            "id": "https://admin-shell.io/zvei/nameplate/1/0/Nameplate/Markings/Marking/MarkingAdditionalText"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "Asset-specific properties"
+                            },
+                            {
+                                "language": "de",
+                                "text": "Asset-spezifische Merkmale"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "Collection of guideline-specific properties"
+                            },
+                            {
+                                "language": "de",
+                                "text": "Sammlung der Richtlinien-spezifischen Merkmale"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "TO_FIX",
+            "modelType": "ConceptDescription",
+            "id": "https://admin-shell.io/zvei/nameplate/1/0/Nameplate/AssetSpecificProperties"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "Guideline-specific Properties"
+                            },
+                            {
+                                "language": "de",
+                                "text": "Richtlinie-spezifische Merkmale"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "Asset specific nameplate information required by guideline, stipulation or legislation"
+                            },
+                            {
+                                "language": "de",
+                                "text": "Asset-spezifische Typenschildinformation, die von weiteren Normen, Standards und Richtlinien gefordert wird"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "TO_FIX",
+            "modelType": "ConceptDescription",
+            "id": "https://admin-shell.io/zvei/nameplate/1/0/Nameplate/AssetSpecificProperties/GuidelineSpecificProperties"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "guideline for conformity declaration"
+                            },
+                            {
+                                "language": "de",
+                                "text": "Richtlinie der Konformit\u00e4tserkl\u00e4rung"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "guideline, stipulation or legislation used for determining conformity"
+                            },
+                            {
+                                "language": "de",
+                                "text": "Richtlinie, Vorschrift oder des Gesetzes an Hand der die Konformit\u00e4t ermittelt wurde"
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "GuiForConDec"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "TO_FIX",
+            "modelType": "ConceptDescription",
+            "id": "0173-1#02-AAO856#002",
+            "isCaseOf": [
+                {
+                    "type": "ExternalReference",
+                    "keys": [
+                        {
+                            "type": "GlobalReference",
+                            "value": "0173-1#02-AAO856#002"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "Comment"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "de",
+                                "text": "States a user-defined comment. Can be freely defined, even in multiple languages."
+                            }
+                        ],
+                        "sourceOfDefinition": "[ISO 15519-1:2010]"
+                    }
+                }
+            ],
+            "idShort": "Comment",
+            "modelType": "ConceptDescription",
+            "id": "https://admin-shell.io/vdi/2770/1/0/Comment"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "de",
+                                "text": "Version des Dokuments"
+                            },
+                            {
+                                "language": "en",
+                                "text": "modelFileVersion"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "de",
+                                "text": "Zu jedem Dokument muss eine Menge von mindestens einer Dokumentenversion existieren. Es k\u00f6nnen auch mehrere Dokumentenversionen ausgeliefert werden."
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "modelFileVersion",
+            "modelType": "ConceptDescription",
+            "id": "https://admin-shell.io/vdi/2770/1/0/modelFileVersion"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "ModelVersionId"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "de",
+                                "text": "Verschiedene Versionen eines Dokuments m\u00fcssen eindeutig identifizierbar sein. Die DocumentVersionId stellt eine innerhalb einer Dom\u00e4ne eindeutige Versionsidentifikationsnummer dar."
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "modelVersionIdValue",
+            "modelType": "ConceptDescription",
+            "id": "https://admin-shell.io/vdi/2770/1/0/modelVersionId/Val"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "DigitalFile"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "de",
+                                "text": "Eine Datei, die die DocumentVersion repr\u00e4sentiert. Neben der obligatorischen PDF/A Datei k\u00f6nnen weitere Dateien angegeben werden."
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "DigitalFile_00_",
+            "modelType": "ConceptDescription",
+            "id": "https://admin-shell.io/vdi/2770/1/0/StoredDocumentRepresentation/DigitalFile"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "DigitalFile"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "Provides a preview image of the Document, e.g. first page, in a commonly used image format and low resolution."
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "PreviewFile",
+            "modelType": "ConceptDescription",
+            "id": "https://admin-shell.io/vdi/2770/1/0/StoredDocumentRepresentation/PreviewFile"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "name of supplier"
+                            },
+                            {
+                                "language": "de",
+                                "text": "Lieferantenname"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "de",
+                                "text": "Name des Lieferanten, welcher dem Kunden ein Produkt oder eine Dienstleistung bereitstellt"
+                            },
+                            {
+                                "language": "en",
+                                "text": "name of supplier which provides the customer with a product or a service"
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "name of supplier"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "NameOfSupplier",
+            "modelType": "ConceptDescription",
+            "id": "0173-1#02-AAO735#003",
+            "administration": {}
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "de",
+                                "text": "Landeskennung"
+                            },
+                            {
+                                "language": "en",
+                                "text": "Country code"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "de",
+                                "text": "Vereinbartes Merkmal zur eindeutigen Identifizierung eines Landes"
+                            },
+                            {
+                                "language": "en",
+                                "text": "agreed upon symbol for unambiguous identification of a country"
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "Country code"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "CountryCode",
+            "modelType": "ConceptDescription",
+            "id": "0173-1#02-AAO730#001",
+            "administration": {}
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "de",
+                                "text": "Strasse"
+                            },
+                            {
+                                "language": "en",
+                                "text": "Street"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "de",
+                                "text": "Name der Strasse und Hausnummer"
+                            },
+                            {
+                                "language": "en",
+                                "text": "Street name and house number"
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "Street"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "Street",
+            "modelType": "ConceptDescription",
+            "id": "0173-1#02-AAO128#001"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "de",
+                                "text": "Ort"
+                            },
+                            {
+                                "language": "en",
+                                "text": "City/town"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "Town or city of the company"
+                            },
+                            {
+                                "language": "de",
+                                "text": "Ortsangabe"
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "City/town"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "CityTown",
+            "modelType": "ConceptDescription",
+            "id": "0173-1#02-AAO132#001"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "de",
+                                "text": "Internetadresse"
+                            },
+                            {
+                                "language": "en",
+                                "text": "Internet address"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "stated as link to a home page. The home page is the starting page or table of contents of a web site with offerings. It usually has the name index.htm or index.html"
+                            },
+                            {
+                                "language": "de",
+                                "text": "Angabe als Link, um in eine Homepage zu gelangen. die Homepage ist die Start- beziehungsweise die Inhaltsseite eines Web-Angebots. Meistens tr\u00e4gt sie den Namen index.htm oder index.html"
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "URL"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "URL",
+            "modelType": "ConceptDescription",
+            "id": "0173-1#02-AAO694#001"
+        },
+        {
+            "embeddedDataSpecifications": [
+                {
+                    "dataSpecification": {
+                        "type": "ExternalReference",
+                        "keys": [
+                            {
+                                "type": "GlobalReference",
+                                "value": "http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0"
+                            }
+                        ]
+                    },
+                    "dataSpecificationContent": {
+                        "modelType": "DataSpecificationIec61360",
+                        "preferredName": [
+                            {
+                                "language": "en",
+                                "text": "tbd"
+                            },
+                            {
+                                "language": "de",
+                                "text": "tbd"
+                            }
+                        ],
+                        "definition": [
+                            {
+                                "language": "en",
+                                "text": "Description of the Connector Port."
+                            },
+                            {
+                                "language": "de",
+                                "text": "Beschreibung des Port-Connectors."
+                            }
+                        ],
+                        "shortName": [
+                            {
+                                "language": "en",
+                                "text": "PortConDescription"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "idShort": "portConDescription",
+            "modelType": "ConceptDescription",
+            "id": "https://admin-shell.io/idta/SimulationModels/portConDescription/1/0"
+        }
+    ]
 }


### PR DESCRIPTION
The working group for the provison pof simultion model has created a bugfix for the incorrect generic forms. This was necessary because the aasx contained outdated concept descriptions which referred to the sandbox status and not to the IDTA specification. The incorrect CDDs were removed or corrected. Created a new generic forms.