### PR TITLE
Maintenance Instructions: fix: correct cardinality typos (ZerotoMany→ZeroToMany, ZerotToOne→ZeroToOne)

### DIFF
--- a/published/Maintenance Instructions/1/0/IDTA_02018_Template_MaintenanceInstructions.json
+++ b/published/Maintenance Instructions/1/0/IDTA_02018_Template_MaintenanceInstructions.json
@@ -326,7 +326,7 @@
                         {
                           "type": "SMT/Cardinality",
                           "valueType": "xs:string",
-                          "value": "ZerotToOne"
+                          "value": "ZeroToOne"
                         }
                       ],
                       "valueType": "xs:string",
@@ -585,7 +585,7 @@
                     {
                       "type": "SMT/Cardinality",
                       "valueType": "xs:string",
-                      "value": "ZerotoMany"
+                      "value": "ZeroToMany"
                     }
                   ],
                   "value": [
@@ -2516,7 +2516,7 @@
                     {
                       "type": "SMT/Cardinality",
                       "valueType": "xs:string",
-                      "value": "ZerotToOne"
+                      "value": "ZeroToOne"
                     }
                   ],
                   "value": [
@@ -2546,7 +2546,7 @@
                         {
                           "type": "SMT/Cardinality",
                           "valueType": "xs:string",
-                          "value": "ZerotToOne"
+                          "value": "ZeroToOne"
                         }
                       ],
                       "value": [
@@ -2931,7 +2931,7 @@
                     {
                       "type": "SMT/Cardinality",
                       "valueType": "xs:string",
-                      "value": "ZerotToOne"
+                      "value": "ZeroToOne"
                     }
                   ],
                   "value": [
@@ -2961,7 +2961,7 @@
                         {
                           "type": "SMT/Cardinality",
                           "valueType": "xs:string",
-                          "value": "ZerotToOne"
+                          "value": "ZeroToOne"
                         }
                       ],
                       "value": [
@@ -3091,7 +3091,7 @@
                     {
                       "type": "SMT/Cardinality",
                       "valueType": "xs:string",
-                      "value": "ZerotToOne"
+                      "value": "ZeroToOne"
                     }
                   ],
                   "valueType": "xs:string",
@@ -3378,7 +3378,7 @@
                     {
                       "type": "SMT/Cardinality",
                       "valueType": "xs:string",
-                      "value": "ZerotToOne"
+                      "value": "ZeroToOne"
                     }
                   ],
                   "modelType": "MultiLanguageProperty"
@@ -3409,7 +3409,7 @@
                     {
                       "type": "SMT/Cardinality",
                       "valueType": "xs:string",
-                      "value": "ZerotToOne"
+                      "value": "ZeroToOne"
                     }
                   ],
                   "value": [
@@ -3439,7 +3439,7 @@
                         {
                           "type": "SMT/Cardinality",
                           "valueType": "xs:string",
-                          "value": "ZerotToOne"
+                          "value": "ZeroToOne"
                         }
                       ],
                       "value": [
@@ -3469,7 +3469,7 @@
                             {
                               "type": "SMT/Cardinality",
                               "valueType": "xs:string",
-                              "value": "ZerotToOne"
+                              "value": "ZeroToOne"
                             }
                           ],
                           "valueType": "xs:decimal",
@@ -3596,7 +3596,7 @@
                     {
                       "type": "SMT/Cardinality",
                       "valueType": "xs:string",
-                      "value": "ZerotToOne"
+                      "value": "ZeroToOne"
                     }
                   ],
                   "valueType": "xs:string",


### PR DESCRIPTION
## Summary

Fixes #279

The Maintenance Instructions template JSON file contains typos in cardinality qualifier values: "ZerotoMany" and "ZerotToOne" instead of the correct CamelCase "ZeroToMany" and "ZeroToOne".

## Root Cause

In `published/Maintenance Instructions/1/0/IDTA_02018_Template_MaintenanceInstructions.json`, 12 cardinality qualifier entries use incorrect casing:
- `"value": "ZerotoMany"` (1 occurrence, line 588) — missing capital "M"
- `"value": "ZerotToOne"` (11 occurrences) — missing capital "O" in "Zero" and lowercase "t" in "To"

These appear to be copy-paste artifacts where the original CamelCase was lost.

## Fix

Applied targeted find-and-replace across all 12 occurrences in the JSON file:
- `"ZerotoMany"` → `"ZeroToMany"` (1 place)
- `"ZerotToOne"` → `"ZeroToOne"` (11 places)

All other cardinality values in the file (e.g., "One", "ZeroToMany", "OneToMany") already use correct CamelCase — these 12 were the only outliers.

## Changes

- `published/Maintenance Instructions/1/0/IDTA_02018_Template_MaintenanceInstructions.json`: fix cardinality value casing (`+12 −12` lines)

## Testing

- **JSON validity**: file parses successfully after edit ✅
- **All 12 cardinality qualifiers**: now use correct CamelCase ✅
- **Other cardinality values in file**: unchanged and consistent ✅